### PR TITLE
Poloniex order book and trades

### DIFF
--- a/xchange-poloniex/pom.xml
+++ b/xchange-poloniex/pom.xml
@@ -25,5 +25,11 @@
             <artifactId>xchange-poloniex</artifactId>
             <version>${xchange.version}</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>22.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/utils/MinMaxPriorityQueueUtils.java
+++ b/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/utils/MinMaxPriorityQueueUtils.java
@@ -1,0 +1,20 @@
+package info.bitrich.xchangestream.poloniex.utils;
+
+
+import com.google.common.collect.MinMaxPriorityQueue;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class MinMaxPriorityQueueUtils {
+  public static <T> List toList(MinMaxPriorityQueue<T> queue, Comparator<? super T> comparator){
+    List<T> list = new ArrayList<T>(queue.size());
+    for (T e : queue)
+      list.add(e);
+    if (comparator!=null){
+      list.sort(comparator);
+    }
+    return list;
+  }
+}


### PR DESCRIPTION
Adding Trades and Order Book for poloniex.

Shortcomings:
Poloniex only returns changed order book levels, we have to keep track of full order book manually, hence I included guava for MinMaxPriorityQueue so we keep 100 levels. 

If something goes wrong(e.g. if we miss some poloniex sequenceNumber), wrong data may stay in book longer than 1 book update. Also, book will be populated gradually, in the beginning it may be empty.

I only see order book when subscribed to new CurrencyPair("BTC", "ETH"), but I only see ticket when subscribed to new CurrencyPair("ETH", "BTC")