### PR TITLE
Change subscribing to channel, allow adding arguments

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -123,7 +123,7 @@ public abstract class NettyStreamingService<T> {
 
     protected abstract String getChannelNameFromMessage(T message) throws IOException;
 
-    public abstract String getSubscribeMessage(String channelName) throws IOException;
+    public abstract String getSubscribeMessage(String channelName, Object... args) throws IOException;
 
     public abstract String getUnsubscribeMessage(String channelName) throws IOException;
 
@@ -151,7 +151,7 @@ public abstract class NettyStreamingService<T> {
         webSocketChannel.writeAndFlush(frame);
     }
 
-    public Observable<T> subscribeChannel(String channelName) {
+    public Observable<T> subscribeChannel(String channelName, Object... args) {
         LOG.info("Subscribing to channel {}", channelName);
 
         return Observable.<T>create(e -> {
@@ -161,7 +161,7 @@ public abstract class NettyStreamingService<T> {
 
             channels.put(channelName, e);
             try {
-                sendMessage(getSubscribeMessage(channelName));
+                sendMessage(getSubscribeMessage(channelName, args));
             } catch (IOException throwable) {
                 e.onError(throwable);
             }

--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
@@ -39,7 +39,7 @@ public class GDAXStreamingService extends JsonNettyStreamingService {
    * @return an Observable of json objects coming from the exchange.
    */
   @Override
-  public Observable<JsonNode> subscribeChannel(String channelName) {
+  public Observable<JsonNode> subscribeChannel(String channelName, Object... args) {
     if (!channels.containsKey(channelName) && !subscriptions.containsKey(channelName)){
       subscriptions.put(channelName, super.subscribeChannel(channelName));
     } 
@@ -53,7 +53,7 @@ public class GDAXStreamingService extends JsonNettyStreamingService {
   }
 
   @Override
-  public String getSubscribeMessage(String channelName) throws IOException {
+  public String getSubscribeMessage(String channelName, Object... args) throws IOException {
     GDAXWebSocketSubscriptionMessage subscribeMessage = 
       new GDAXWebSocketSubscriptionMessage(SUBSCRIBE, channelName);
     ObjectMapper objectMapper = new ObjectMapper();

--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingService.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingService.java
@@ -20,7 +20,7 @@ public class OkCoinStreamingService extends JsonNettyStreamingService {
     }
 
     @Override
-    public String getSubscribeMessage(String channelName) throws IOException {
+    public String getSubscribeMessage(String channelName, Object... args) throws IOException {
         WebSocketMessage webSocketMessage = new WebSocketMessage("addChannel", channelName);
 
         ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
Additional arguments may be used to construct subscription message. For instance, this would be used for Bitfinex which also requires a symbol when creating subscription message.