### PR TITLE
Poloniex: Fix Base/Counter inversion to subscribe channel

### DIFF
--- a/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingMarketDataService.java
+++ b/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingMarketDataService.java
@@ -111,7 +111,7 @@ public class PoloniexStreamingMarketDataService implements StreamingMarketDataSe
 
     @Override
     public Observable<Trade> getTrades(CurrencyPair currencyPair, Object... args) {
-        String channel = currencyPair.toString().replace("/", "_");
+        String channel = PoloniexUtils.toPairString(currencyPair);
         Observable<Trade> result = streamingService.subscribeChannel(channel)
                 .flatMap(pubSubData -> {
                     List<Trade> res = new ArrayList<Trade>();

--- a/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingMarketDataService.java
+++ b/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingMarketDataService.java
@@ -53,7 +53,7 @@ public class PoloniexStreamingMarketDataService implements StreamingMarketDataSe
             askQueue = orderBookAsks.get(currencyPair);
         }
 
-        String channel = currencyPair.toString().replace("/", "_");
+        String channel = PoloniexUtils.toPairString(currencyPair);
         Observable<OrderBook> result = streamingService.subscribeChannel(channel)
                 .map(pubSubData -> {
                     Date now = new Date();


### PR DESCRIPTION
Base and counter currency were inverted because of a wrong conversion during channel subscription, I changed to use the conversion from PoloniexUtils.toPairString(currencyPair); which is the right one