### PR TITLE
Convert v2 timestamp (msec) to v1 timestamp (sec).

### DIFF
--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
@@ -49,6 +49,6 @@ public class BitfinexWebSocketTrade {
             type = "buy";
         }
 
-        return new BitfinexTrade(price, amount, timestamp,"bitfinex", tradeId, type);
+        return new BitfinexTrade(price, amount, timestamp / 1000,"bitfinex", tradeId, type);
     }
 }


### PR DESCRIPTION
Great library, many many thanks! When using the BitfinexStreamingExchange, I noticed that Bitfinex had changed their timestamp unit in their WebSocket API v2. Hope this helps! Kind regards, Ferdinand.