### PR TITLE
Add isAlive method to StreamingExchange and underlying services

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -129,11 +129,13 @@ public abstract class NettyStreamingService<T> {
 
     public Completable disconnect() {
         return Completable.create(completable -> {
-            CloseWebSocketFrame closeFrame = new CloseWebSocketFrame();
-            webSocketChannel.writeAndFlush(closeFrame).addListener(future -> {
-                channels = new ConcurrentHashMap<>();
-                completable.onComplete();
-            });
+        		if (webSocketChannel.isOpen()) {
+	            CloseWebSocketFrame closeFrame = new CloseWebSocketFrame();
+	            webSocketChannel.writeAndFlush(closeFrame).addListener(future -> {
+	                channels = new ConcurrentHashMap<>();
+	                completable.onComplete();
+	            });
+        		}
         });
     }
 
@@ -260,5 +262,9 @@ public abstract class NettyStreamingService<T> {
     protected WebSocketClientHandler getWebSocketClientHandler(WebSocketClientHandshaker handshaker, 
                                                                WebSocketClientHandler.WebSocketMessageHandler handler){
         return new WebSocketClientHandler(handshaker, handler);
+    }
+    
+    public boolean isSocketOpen() {
+    		return webSocketChannel.isOpen();
     }
 }

--- a/service-pubnub/src/main/java/info/bitrich/xchangestream/service/pubnub/PubnubStreamingService.java
+++ b/service-pubnub/src/main/java/info/bitrich/xchangestream/service/pubnub/PubnubStreamingService.java
@@ -48,7 +48,7 @@ public class PubnubStreamingService {
           public void status(PubNub pubNub, PNStatus pnStatus) {
             pnStatusCategory = pnStatus.getCategory();
             LOG.debug("PubNub status: {} {}", pnStatusCategory.toString(), pnStatus.getStatusCode());
-            if (pnStatus.getCategory() == PNStatusCategory.PNConnectedCategory) {
+            if (pnStatusCategory == PNStatusCategory.PNConnectedCategory) {
 //              e.onComplete();
             } else if (pnStatus.isError()) {
 //              e.onError(pnStatus.getErrorData().getThrowable());
@@ -101,5 +101,9 @@ public class PubnubStreamingService {
       pubnub.disconnect();
       completable.onComplete();
     });
+  }
+  
+  public boolean isAlive() {
+	return (pnStatusCategory == PNStatusCategory.PNConnectedCategory);
   }
 }

--- a/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
+++ b/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
@@ -86,4 +86,8 @@ public class PusherStreamingService {
             }
         }).doOnDispose(() -> pusher.unsubscribe(channelName));
     }
+    
+    public boolean isSocketOpen() {
+		return pusher.getConnection().getState() == ConnectionState.CONNECTED;
+}
 }

--- a/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
+++ b/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
@@ -4,11 +4,14 @@ import hu.akarnokd.rxjava.interop.RxJavaInterop;
 import info.bitrich.xchangestream.service.exception.NotConnectedException;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
+import rx.subjects.BehaviorSubject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ws.wamp.jawampa.PubSubData;
 import ws.wamp.jawampa.WampClient;
 import ws.wamp.jawampa.WampClientBuilder;
+import ws.wamp.jawampa.WampClient.State;
 import ws.wamp.jawampa.connection.IWampConnectorProvider;
 import ws.wamp.jawampa.transport.netty.NettyWampClientConnectorProvider;
 
@@ -75,5 +78,10 @@ public class WampStreamingService {
         }
 
         return RxJavaInterop.toV2Observable(client.makeSubscription(channel));
+    }
+    
+    public boolean isSocketOpen() {
+    		// WampClient was initiated with infinite reconnects attempts, so we can just always return 'true' 
+		return !((BehaviorSubject<State>) client.statusChanged()).hasCompleted();
     }
 }

--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -35,6 +35,11 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
     }
 
     @Override
+    public boolean isAlive() {
+        throw new IllegalStateException("Not implemented.");
+    }
+
+    @Override
     public StreamingMarketDataService getStreamingMarketDataService() {
       return streamingMarketDataService;
     }

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingExchange.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingExchange.java
@@ -35,6 +35,11 @@ public class BitfinexStreamingExchange extends BitfinexExchange implements Strea
     public Completable disconnect() {
         return streamingService.disconnect();
     }
+    
+    @Override 
+    public boolean isAlive() {
+    		return streamingService.isSocketOpen();
+    }
 
     @Override
     public ExchangeSpecification getDefaultExchangeSpecification() {

--- a/xchange-bitflyer/src/main/java/info/bitrich/xchangestream/bitflyer/BitflyerStreamingExchange.java
+++ b/xchange-bitflyer/src/main/java/info/bitrich/xchangestream/bitflyer/BitflyerStreamingExchange.java
@@ -53,5 +53,10 @@ public class BitflyerStreamingExchange extends BaseExchange implements Streaming
   public StreamingMarketDataService getStreamingMarketDataService() {
     return streamingMarketDataService;
   }
+
+  @Override
+  public boolean isAlive() {
+	return streamingService.isAlive();
+  }
 }
 

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
@@ -52,4 +52,9 @@ public class BitmexStreamingExchange extends BaseExchange implements StreamingEx
   public StreamingMarketDataService getStreamingMarketDataService() {
     return streamingMarketDataService;
   }
+
+  @Override
+  public boolean isAlive() {
+	  return streamingService.isSocketOpen();	
+  }
 }

--- a/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingExchange.java
+++ b/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingExchange.java
@@ -37,4 +37,9 @@ public class BitstampStreamingExchange extends BitstampExchange implements Strea
     public StreamingMarketDataService getStreamingMarketDataService() {
         return streamingMarketDataService;
     }
+
+	@Override
+	public boolean isAlive() {
+		return this.streamingService.isSocketOpen();
+	}
 }

--- a/xchange-coinmate/src/main/java/info/bitrich/xchange/coinmate/CoinmateStreamingExchange.java
+++ b/xchange-coinmate/src/main/java/info/bitrich/xchange/coinmate/CoinmateStreamingExchange.java
@@ -37,4 +37,9 @@ public class CoinmateStreamingExchange extends CoinmateExchange implements Strea
     public StreamingMarketDataService getStreamingMarketDataService() {
         return streamingMarketDataService;
     }
+
+	@Override
+	public boolean isAlive() {
+		return streamingService.isSocketOpen();
+	}
 }

--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
@@ -60,4 +60,9 @@ public class GDAXStreamingExchange extends GDAXExchange implements StreamingExch
   public void setChannelInactiveHandler(WebSocketClientHandler.WebSocketMessageHandler channelInactiveHandler) {
     streamingService.setChannelInactiveHandler(channelInactiveHandler);
   }
+
+  @Override
+  public boolean isAlive() {
+	return streamingService.isSocketOpen();
+  }
 }

--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingExchange.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingExchange.java
@@ -40,4 +40,9 @@ public class GeminiStreamingExchange extends GeminiExchange implements Streaming
   public StreamingMarketDataService getStreamingMarketDataService() {
     return streamingMarketDataService;
   }
+
+  @Override
+  public boolean isAlive() {
+	return streamingService.isAlive();
+  }
 }

--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingService.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingService.java
@@ -38,4 +38,9 @@ public class GeminiStreamingService {
 
     return productSubscriptions.get(currencyPair);
   }
+  
+  public boolean isAlive() {
+	return productStreamingServices.values().stream()
+			.allMatch(ps -> ps.isSocketOpen());
+  }
 }

--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingExchange.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingExchange.java
@@ -35,6 +35,11 @@ public class OkCoinStreamingExchange extends OkCoinExchange implements Streaming
     public Completable disconnect() {
         return streamingService.disconnect();
     }
+    
+    @Override
+	public boolean isAlive() {
+		return streamingService.isSocketOpen();
+	}
 
     @Override
     public StreamingMarketDataService getStreamingMarketDataService() {

--- a/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingExchange.java
+++ b/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingExchange.java
@@ -38,4 +38,9 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
     public StreamingMarketDataService getStreamingMarketDataService() {
         return streamingMarketDataService;
     }
+
+	@Override
+	public boolean isAlive() {
+		return true;
+	}
 }

--- a/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingExchange.java
+++ b/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingExchange.java
@@ -41,6 +41,6 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
 
 	@Override
 	public boolean isAlive() {
-		return true;
+		return streamingService.isSocketOpen();
 	}
 }

--- a/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
+++ b/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
@@ -82,4 +82,9 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
   public StreamingMarketDataService getStreamingMarketDataService() {
     return streamingMarketDataService;
   }
+
+  @Override
+  public boolean isAlive() {
+	  return streamingService.isSocketOpen();
+  }
 }

--- a/xchange-stream-core/pom.xml
+++ b/xchange-stream-core/pom.xml
@@ -15,6 +15,12 @@
             <artifactId>service-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>info.bitrich.xchange-stream</groupId>
+            <artifactId>service-netty</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.knowm.xchange</groupId>

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
@@ -18,6 +18,8 @@ public interface StreamingExchange extends Exchange {
      * @return {@link Completable} that completes upon successful disconnect.
      */
     Completable disconnect();
+    
+    boolean isAlive();
 
     /**
      * Returns service that can be used to access market data.

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
@@ -18,7 +18,12 @@ public interface StreamingExchange extends Exchange {
      * @return {@link Completable} that completes upon successful disconnect.
      */
     Completable disconnect();
-    
+
+    /**
+     * Checks whether connection to the exchange is alive.
+     *
+     * @return true if connection is open, otherwise false.
+     */
     boolean isAlive();
 
     /**

--- a/xchange-wex/src/main/java/info/bitrich/xchangestream/wex/WexStreamingExchange.java
+++ b/xchange-wex/src/main/java/info/bitrich/xchangestream/wex/WexStreamingExchange.java
@@ -41,4 +41,9 @@ public class WexStreamingExchange extends BTCEExchange implements StreamingExcha
   public StreamingMarketDataService getStreamingMarketDataService() {
     return streamingMarketDataService;
   }
+
+  @Override
+  public boolean isAlive() {
+	return this.streamingService.isSocketOpen();
+}
 }


### PR DESCRIPTION
  - Add isSocketOpen to
  - Add isAlive at StreamingExchange interface
  - Implement isAlive at poloniex2, wex, bitstamp and bitfinex

It allows user to check whether websocket is opened and handle disconnections. It also makes the 'disconnect' command safe by not writing to an already disconnected channel.

Using this API the user can check connection status and reconnect if needed, then user can resubscribe to all channels.

Sometimes subscribing to channel could raise exception and kill the connection (e.g channel not exist on exchange), so I prefered not to create re-subscription mechanism at service level, but leave it to the user. 

This is on top of the disconnect event, as it allows user to check connection status in sync manner as well. 