### PR TITLE
Bugfix/bitfinex orderbook showing future timestamps

### DIFF
--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbook.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbook.java
@@ -1,5 +1,7 @@
 package info.bitrich.xchangestream.bitfinex.dto;
 
+import static java.math.BigDecimal.ZERO;
+
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexDepth;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLevel;
 
@@ -12,7 +14,6 @@ import java.util.*;
 public class BitfinexOrderbook {
     private Map<BigDecimal, BitfinexOrderbookLevel> asks;
     private Map<BigDecimal, BitfinexOrderbookLevel> bids;
-    private BigDecimal zero = new BigDecimal(0);
 
     public BitfinexOrderbook(BitfinexOrderbookLevel[] levels) {
         createFromLevels(levels);
@@ -35,9 +36,8 @@ public class BitfinexOrderbook {
         this.asks = new HashMap<>(levels.length/2);
         this.bids = new HashMap<>(levels.length/2);
 
-        BigDecimal zero = new BigDecimal(0);
         for (BitfinexOrderbookLevel level : levels) {
-            if (level.getAmount().compareTo(zero) > 0) bids.put(level.getOrderId(), level);
+            if (level.getAmount().compareTo(ZERO) > 0) bids.put(level.getOrderId(), level);
             else asks.put(level.getOrderId(), level);
         }
     }
@@ -68,8 +68,8 @@ public class BitfinexOrderbook {
     }
 
     public void updateLevel(BitfinexOrderbookLevel level) {
-        Map<BigDecimal, BitfinexOrderbookLevel> side = level.getAmount().compareTo(zero) > 0 ? bids : asks;
-        boolean shouldDelete = level.getPrice().compareTo(zero) == 0;
+        Map<BigDecimal, BitfinexOrderbookLevel> side = level.getAmount().compareTo(ZERO) > 0 ? bids : asks;
+        boolean shouldDelete = level.getPrice().compareTo(ZERO) == 0;
 
         side.remove(level.orderId);
         if (!shouldDelete) {

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbookLevel.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbookLevel.java
@@ -35,6 +35,7 @@ public class BitfinexOrderbookLevel {
     }
 
     public BitfinexLevel toBitfinexLevel() {
-        return new BitfinexLevel(price, amount, new BigDecimal(System.currentTimeMillis()));
+        // Xchange-bitfinex adapter expects the timestamp to be seconds since Epoch.
+        return new BitfinexLevel(price, amount, new BigDecimal(System.currentTimeMillis()/1000));
     }
 }

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
@@ -42,8 +42,7 @@ public class BitfinexWebSocketTrade {
 
     public BitfinexTrade toBitfinexTrade() {
         String type;
-        BigDecimal zero = new BigDecimal(0);
-        if (amount.compareTo(zero) < 0) {
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
             type = "sell";
         } else {
             type = "buy";

--- a/xchange-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbookTest.java
+++ b/xchange-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbookTest.java
@@ -1,0 +1,28 @@
+package info.bitrich.xchangestream.bitfinex.dto;
+
+import static java.math.BigDecimal.ONE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.knowm.xchange.currency.CurrencyPair.BTC_USD;
+
+import java.util.Date;
+import org.junit.Test;
+import org.knowm.xchange.bitfinex.v1.BitfinexAdapters;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexDepth;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+
+public class BitfinexOrderbookTest {
+
+    @Test
+    public void timestampShouldBeInSeconds() {
+        BitfinexDepth depth = new BitfinexOrderbook(new BitfinexOrderbookLevel[]{
+            new BitfinexOrderbookLevel(ONE, ONE, ONE),
+            new BitfinexOrderbookLevel(ONE, ONE, ONE)
+        }).toBitfinexDepth();
+
+        OrderBook orderBook = BitfinexAdapters.adaptOrderBook(depth, BTC_USD);
+
+        // What is the time now... after order books created?
+        assertThat("The timestamp should be a value less than now, but was: " + orderBook.getTimeStamp(),
+            !orderBook.getTimeStamp().after(new Date()));
+    }
+}

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingMarketDataService.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingMarketDataService.java
@@ -22,7 +22,7 @@ public interface StreamingMarketDataService {
      * Emits {@link info.bitrich.xchangestream.service.exception.NotConnectedException} When not connected to the WebSocket API.
      *
      * @param currencyPair Currency pair of the ticker
-     * @return {@link Observable} that emits {@link OrderBook} when exchange sends the update.
+     * @return {@link Observable} that emits {@link Ticker} when exchange sends the update.
      */
     Observable<Ticker> getTicker(CurrencyPair currencyPair, Object... args);
 
@@ -31,7 +31,7 @@ public interface StreamingMarketDataService {
      * Emits {@link info.bitrich.xchangestream.service.exception.NotConnectedException} When not connected to the WebSocket API.
      *
      * @param currencyPair Currency pair of the trades
-     * @return {@link Observable} that emits {@link OrderBook} when exchange sends the update.
+     * @return {@link Observable} that emits {@link Trade} when exchange sends the update.
      */
     Observable<Trade> getTrades(CurrencyPair currencyPair, Object... args);
 }


### PR DESCRIPTION
The effect is a little odd, since the localized output of Dates for me is something like 

```
 Sat Nov 21 09:46:52 NZDT 49925
```

I initially thought it was a historical orderbook stream ;-) Then I realized the year was *49925*