### PR TITLE
Fixing orderbook timestamp when converting to XChange order book

### DIFF
--- a/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingMarketDataService.java
+++ b/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingMarketDataService.java
@@ -32,7 +32,7 @@ public class BitstampStreamingMarketDataService implements StreamingMarketDataSe
                     ObjectMapper mapper = new ObjectMapper();
                     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                     BitstampOrderBook orderBook = mapper.readValue(s, BitstampOrderBook.class);
-                    org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook bitstampOrderBook = new org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook(new Date().getTime(), orderBook.getBids(), orderBook.getAsks());
+                    org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook bitstampOrderBook = new org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook(new Date().getTime() / 1000L, orderBook.getBids(), orderBook.getAsks());
 
                     return BitstampAdapters.adaptOrderBook(bitstampOrderBook, currencyPair);
                 });


### PR DESCRIPTION
to fix issue #59 
the /1000L is already on Trade API; currently without /1000L the order book timestamp is 1000 times in the future 