### PR TITLE
fix for gdax reconnect inability

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -266,9 +266,8 @@ public abstract class NettyStreamingService<T> {
         return new NettyWebSocketClientHandler(handshaker, handler);
     }
 
-
-    private class NettyWebSocketClientHandler extends  WebSocketClientHandler{
-        NettyWebSocketClientHandler(WebSocketClientHandshaker handshaker, WebSocketMessageHandler handler) {
+    protected class NettyWebSocketClientHandler extends WebSocketClientHandler {
+        protected NettyWebSocketClientHandler(WebSocketClientHandshaker handshaker, WebSocketMessageHandler handler) {
             super(handshaker, handler);
         }
 

--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
@@ -108,7 +108,7 @@ public class GDAXStreamingService extends JsonNettyStreamingService {
      * Custom client handler in order to execute an external, user-provided handler on channel events.
      * This is useful because it seems GDAX unexpectedly closes the web socket connection.
      */
-    class GDAXWebSocketClientHandler extends WebSocketClientHandler {
+    class GDAXWebSocketClientHandler extends NettyWebSocketClientHandler {
 
         public GDAXWebSocketClientHandler(WebSocketClientHandshaker handshaker, WebSocketMessageHandler handler) {
             super(handshaker, handler);


### PR DESCRIPTION
currently gdax lacks the ability to reconnect because it only extends from WebSocketClientHandler and not from the default one `NettyWebSocketClientHandler`.

I have adjusted it accordingly. the GDAX example still works. 