### PR TITLE
Updates XChange dependency to 4.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     </repositories>
 
     <properties>
-        <xchange.version>4.3.1</xchange.version>
+        <xchange.version>4.3.2</xchange.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/xchange-binance/pom.xml
+++ b/xchange-binance/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-binance</artifactId>
-            <version>4.3.1</version>
+            <version>${xchange.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Updating to XChange 4.3.2 to help with my implementation of the Binance ticker streams. The latest version has a `toTicker` method on the `BinanceTicker24h` and I'd rather use that than duplicate the code.

Let me know if there are any other checks that need to be made.