### PR TITLE
Add handler for compressed websocket messages

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -111,6 +111,7 @@ public abstract class NettyStreamingService<T> {
                                 WebSocketClientExtensionHandler clientExtensionHandler = getWebSocketClientExtensionHandler();
                                 List<ChannelHandler> handlers = new ArrayList<>(4);
                                 handlers.add(new HttpClientCodec());
+                                handlers.add(WebSocketClientCompressionHandler.INSTANCE);
                                 handlers.add(new HttpObjectAggregator(8192));
                                 handlers.add(handler);
                                 if (clientExtensionHandler != null) handlers.add(clientExtensionHandler);


### PR DESCRIPTION
This handler was necessary because Bitmex testnet suddenly startet to send compressed messages.