### PR TITLE
Fix Typo BitstampManualExample.java

### DIFF
--- a/xchange-bitstamp/src/test/java/info/bitrich/xchangestream/bitstamp/BitstampManualExample.java
+++ b/xchange-bitstamp/src/test/java/info/bitrich/xchangestream/bitstamp/BitstampManualExample.java
@@ -29,7 +29,7 @@ public class BitstampManualExample {
         exchange.disconnect().subscribe(() -> LOG.info("Disconnected from the Exchange"));
 
         try {
-            Thread.sleep(100000);
+            Thread.sleep(10000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
At the end "Thread.sleep()" is set to 100 seconds instead of normal 10 seconds like in the other tests examples.

Changed from Thread.sleep(100000) to Thread.sleep(10000)
// Changed from 100 seconds to 10 seconds