### PR TITLE
Fix for BitFinex OrderBook

### DIFF
--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingMarketDataService.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingMarketDataService.java
@@ -41,7 +41,7 @@ public class BitfinexStreamingMarketDataService implements StreamingMarketDataSe
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         Observable<BitfinexWebSocketOrderbookTransaction> subscribedChannel = service.subscribeChannel(channelName,
-                new Object[]{pair, "R0", depth})
+                new Object[]{pair, "P0", depth})
                 .map(s -> {
                     if (s.get(1).get(0).isArray()) return mapper.readValue(s.toString(),
                             BitfinexWebSocketSnapshotOrderbook.class);

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbookLevel.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexOrderbookLevel.java
@@ -1,6 +1,7 @@
 package info.bitrich.xchangestream.bitfinex.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLevel;
 
 import java.math.BigDecimal;
@@ -9,18 +10,22 @@ import java.math.BigDecimal;
  * Created by Lukas Zaoralek on 8.11.17.
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"price","count","amount"})
 public class BitfinexOrderbookLevel {
-    public BigDecimal orderId;
+
     public BigDecimal price;
+
+    public BigDecimal count;
+
     public BigDecimal amount;
 
     public BitfinexOrderbookLevel() {
     }
 
-    public BitfinexOrderbookLevel(BigDecimal price, BigDecimal amount, BigDecimal orderId) {
+    public BitfinexOrderbookLevel(BigDecimal price, BigDecimal count, BigDecimal amount) {
         this.price = price;
         this.amount = amount;
-        this.orderId = orderId;
+        this.count = count;
     }
 
     public BigDecimal getPrice() {
@@ -31,8 +36,8 @@ public class BitfinexOrderbookLevel {
         return amount;
     }
 
-    public BigDecimal getOrderId() {
-        return orderId;
+    public BigDecimal getCount() {
+        return count;
     }
 
     public BitfinexLevel toBitfinexLevel() {

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketUpdateOrderbook.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketUpdateOrderbook.java
@@ -1,6 +1,7 @@
 package info.bitrich.xchangestream.bitfinex.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Created by Lukas Zaoralek on 8.11.17.

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/jackson/BitfinexWebSocketUpdateOrderbookDeserializer.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/jackson/BitfinexWebSocketUpdateOrderbookDeserializer.java
@@ -1,0 +1,20 @@
+package info.bitrich.xchangestream.bitfinex.dto.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import info.bitrich.xchangestream.bitfinex.dto.BitfinexWebSocketUpdateOrderbook;
+
+import java.io.IOException;
+
+public class BitfinexWebSocketUpdateOrderbookDeserializer extends StdDeserializer<BitfinexWebSocketUpdateOrderbook> {
+    protected BitfinexWebSocketUpdateOrderbookDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public BitfinexWebSocketUpdateOrderbook deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        return null;
+    }
+}

--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/dto/GeminiOrderbook.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/dto/GeminiOrderbook.java
@@ -37,7 +37,7 @@ public class GeminiOrderbook {
     public void updateLevel(GeminiLimitOrder level) {
         SortedMap<BigDecimal, GeminiLimitOrder> orderBookSide = level.getSide() == Order.OrderType.ASK ? asks : bids;
         boolean shouldDelete = level.getAmount().compareTo(zero) == 0;
-        BigDecimal price = level.getPrice();
+        BigDecimal price = new BigDecimal(level.getPrice().toString()); // copy of the price is required for thread safety (BigDecimal is not thread safe, and the hashcode can be affected by outside accesses of the value)
         orderBookSide.remove(price);
         if (!shouldDelete) {
             orderBookSide.put(price, level);


### PR DESCRIPTION
This is a re-work of the BitFinex Orderbook implementation - as it was completely broken before. 

Previously, the order book observable was returning entries with negative "originalAmount" values, and  orderIds as the price. This occurred because the implementation was using the R0 precision on the BitFinex API - which sent order add/remove entries, rather than aggregate price levels.

I've changed the implementation to use the P0 (most precise) aggregate price level BitFinex API subscription. I've also tested that the resulting order book appears sane. 