### PR TITLE
Gemini Orderbook Race Condition Fix

### DIFF
--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
@@ -13,12 +13,14 @@ import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.gemini.v1.dto.marketdata.GeminiTrade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.knowm.xchange.gemini.v1.GeminiAdapters.adaptTrades;
 
@@ -55,29 +57,35 @@ public class GeminiStreamingMarketDataService implements StreamingMarketDataServ
 
     @Override
     public Observable<OrderBook> getOrderBook(CurrencyPair currencyPair, Object... args) {
+
         Observable<GeminiOrderbook> subscribedOrderbookSnapshot = service.subscribeChannel(currencyPair, args)
-                .filter(s -> filterEventsByReason(s, "change", "initial"))
                 .map((JsonNode s) -> {
-                    GeminiWebSocketTransaction transaction = mapper.readValue(s.toString(), GeminiWebSocketTransaction.class);
-                    GeminiOrderbook orderbook = transaction.toGeminiOrderbook(currencyPair);
-                    orderbooks.put(currencyPair, orderbook);
-                    return orderbook;
+
+                    if(filterEventsByReason(s, "change", "initial")) {
+                        GeminiWebSocketTransaction transaction = mapper.readValue(s.toString(), GeminiWebSocketTransaction.class);
+                        GeminiOrderbook orderbook = transaction.toGeminiOrderbook(currencyPair);
+                        orderbooks.put(currencyPair, orderbook);
+                        return orderbook;
+
+                    }
+
+                    if(filterEventsByReason(s, "change", "place") ||
+                            filterEventsByReason(s, "change", "cancel") ||
+                            filterEventsByReason(s, "change", "trade")) {
+
+                        GeminiWebSocketTransaction transaction = mapper.readValue(s.toString(), GeminiWebSocketTransaction.class);
+                        GeminiLimitOrder[] levels = transaction.toGeminiLimitOrdersUpdate();
+                        GeminiOrderbook orderbook = orderbooks.get(currencyPair);
+                        orderbook.updateLevels(levels);
+                        return orderbook;
+
+                    }
+
+                    throw new NotYetImplementedForExchangeException();
+
                 });
 
-        Observable<GeminiOrderbook> subscribedOrderbookUpdate = service.subscribeChannel(currencyPair, args)
-                .filter(s -> orderbooks.containsKey(currencyPair) &&
-                        (filterEventsByReason(s, "change", "place") ||
-                                filterEventsByReason(s, "change", "cancel") ||
-                                filterEventsByReason(s, "change", "trade")))
-                .map((JsonNode s) -> {
-                    GeminiWebSocketTransaction transaction = mapper.readValue(s.toString(), GeminiWebSocketTransaction.class);
-                    GeminiLimitOrder[] levels = transaction.toGeminiLimitOrdersUpdate();
-                    GeminiOrderbook orderbook = orderbooks.get(currencyPair);
-                    orderbook.updateLevels(levels);
-                    return orderbook;
-                });
-
-        return subscribedOrderbookUpdate.mergeWith(subscribedOrderbookSnapshot).map(GeminiOrderbook::toOrderbook);
+        return subscribedOrderbookSnapshot.map(GeminiOrderbook::toOrderbook);
     }
 
     @Override

--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
@@ -59,6 +59,12 @@ public class GeminiStreamingMarketDataService implements StreamingMarketDataServ
     public Observable<OrderBook> getOrderBook(CurrencyPair currencyPair, Object... args) {
 
         Observable<GeminiOrderbook> subscribedOrderbookSnapshot = service.subscribeChannel(currencyPair, args)
+                .filter(
+                        s -> filterEventsByReason(s, "change", "initial") ||
+                                filterEventsByReason(s, "change", "place") ||
+                                filterEventsByReason(s, "change", "cancel") ||
+                                filterEventsByReason(s, "change", "trade")
+                )
                 .map((JsonNode s) -> {
 
                     if(filterEventsByReason(s, "change", "initial")) {
@@ -81,7 +87,7 @@ public class GeminiStreamingMarketDataService implements StreamingMarketDataServ
 
                     }
 
-                    throw new NotYetImplementedForExchangeException();
+                    throw new NotYetImplementedForExchangeException(" Unknown message type, even after filtering: " + s.toString());
 
                 });
 

--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/dto/GeminiOrderbook.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/dto/GeminiOrderbook.java
@@ -37,7 +37,7 @@ public class GeminiOrderbook {
     public void updateLevel(GeminiLimitOrder level) {
         SortedMap<BigDecimal, GeminiLimitOrder> orderBookSide = level.getSide() == Order.OrderType.ASK ? asks : bids;
         boolean shouldDelete = level.getAmount().compareTo(zero) == 0;
-        BigDecimal price = level.getPrice();
+        BigDecimal price = new BigDecimal(level.getPrice().toString()); // copy of the price is required for thread safety (BigDecimal is not thread safe, and the hashcode can be affected by outside accesses of the value)
         orderBookSide.remove(price);
         if (!shouldDelete) {
             orderBookSide.put(price, level);


### PR DESCRIPTION
When subscribing to a new order book on Gemini, there is a race condition caused by the current implementation. First the implementation subscribes to the channel, which actually causes the web socket for that order book to be opened. This first subscription filters only for the "initial" snapshot messages. 

Then the implementation subscribes to that channel a second time (using the same web socket). This second subscription filters only for "update" messages. 

The race condition occurs when on the channel an "initial" message is received - the processing time for that is very likely to be longer than the period until the first "update" message. There are then update messages, such as the removing of price levels, that will be skipped - because the initial order book is not yet present. This can cause long term effects on the consistency of the order book. This is condition is exasperated during a period of many reconnects. 