### PR TITLE
use double to prevent loss of time precision

### DIFF
--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTickerTransaction.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTickerTransaction.java
@@ -34,7 +34,7 @@ public class BitfinexWebSocketTickerTransaction {
         BigDecimal high = new BigDecimal(tickerArr[8]);
         BigDecimal last = new BigDecimal(tickerArr[6]);
         // Xchange-bitfinex adapter expects the timestamp to be seconds since Epoch.
-        float timestamp = System.currentTimeMillis() / 1000;
+        double timestamp = System.currentTimeMillis() / 1000;
         BigDecimal volume = new BigDecimal(tickerArr[7]);
 
         return new BitfinexTicker(mid, bid, ask, low, high, last, timestamp, volume);


### PR DESCRIPTION
This helps mitigate problems with #122, but I'm only seeing precision of about 10 seconds.

Users might want to override timestamps ingested by Bitfinex with local time to avoid loss of precision.