### PR TITLE
[xstream] Bumping dependency from 4.3.3 to 4.3.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     </repositories>
 
     <properties>
-        <xchange.version>4.3.3</xchange.version>
+        <xchange.version>4.3.4</xchange.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/dto/TickerBinanceWebsocketTransaction.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/dto/TickerBinanceWebsocketTransaction.java
@@ -57,7 +57,8 @@ public class TickerBinanceWebsocketTransaction extends ProductBinanceWebSocketTr
                 closeTime,
                 firstId,
                 lastId,
-                count);
+                count,
+                symbol);
         ticker.setCurrencyPair(currencyPair);
     }
 


### PR DESCRIPTION
It would be nice to get some concrete releases that track with the underlying Xchange product.  From what I can see the latest streaming release is 4.3.1 where as XChange is up to 4.3.4.

Could a 4.3.4 release get pushed and have dev be placed on 4.3.5-SNAPSHOT?