### PR TITLE
add option for compression handler

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -331,7 +331,5 @@ public abstract class NettyStreamingService<T> {
         return webSocketChannel.isOpen();
     }
 
-    public void useCompressedMessages(boolean compressedMessages) {
-        this.compressedMessages = compressedMessages;
-    }
+    public void useCompressedMessages(boolean compressedMessages) { this.compressedMessages = compressedMessages; }
 }

--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -66,6 +66,7 @@ public abstract class NettyStreamingService<T> {
     protected Duration connectionTimeout;
     protected final NioEventLoopGroup eventLoopGroup;
     protected Map<String, Subscription> channels = new ConcurrentHashMap<>();
+    private boolean compressedMessages = false;
 
     public NettyStreamingService(String apiUrl) {
         this(apiUrl, 65536);
@@ -142,6 +143,7 @@ public abstract class NettyStreamingService<T> {
                                 WebSocketClientExtensionHandler clientExtensionHandler = getWebSocketClientExtensionHandler();
                                 List<ChannelHandler> handlers = new ArrayList<>(4);
                                 handlers.add(new HttpClientCodec());
+                                if (compressedMessages) handlers.add(WebSocketClientCompressionHandler.INSTANCE);
                                 handlers.add(new HttpObjectAggregator(8192));
                                 handlers.add(handler);
                                 if (clientExtensionHandler != null) handlers.add(clientExtensionHandler);
@@ -327,5 +329,9 @@ public abstract class NettyStreamingService<T> {
 
     public boolean isSocketOpen() {
         return webSocketChannel.isOpen();
+    }
+
+    public void useCompressedMessages(boolean compressedMessages) {
+        this.compressedMessages = compressedMessages;
     }
 }

--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -65,7 +65,7 @@ public abstract class NettyStreamingService<T> {
     private Duration retryDuration;
     private Duration connectionTimeout;
     private final NioEventLoopGroup eventLoopGroup;
-    private Map<String, Subscription> channels = new ConcurrentHashMap<>();
+    protected Map<String, Subscription> channels = new ConcurrentHashMap<>();
     private boolean compressedMessages = false;
 
     public NettyStreamingService(String apiUrl) {

--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -58,14 +58,14 @@ public abstract class NettyStreamingService<T> {
         }
     }
 
-    protected final int maxFramePayloadLength;
-    protected final URI uri;
+    private final int maxFramePayloadLength;
+    private final URI uri;
     private boolean isManualDisconnect = false;
-    protected Channel webSocketChannel;
+    private Channel webSocketChannel;
     private Duration retryDuration;
-    protected Duration connectionTimeout;
-    protected final NioEventLoopGroup eventLoopGroup;
-    protected Map<String, Subscription> channels = new ConcurrentHashMap<>();
+    private Duration connectionTimeout;
+    private final NioEventLoopGroup eventLoopGroup;
+    private Map<String, Subscription> channels = new ConcurrentHashMap<>();
     private boolean compressedMessages = false;
 
     public NettyStreamingService(String apiUrl) {

--- a/service-pubnub/src/main/java/info/bitrich/xchangestream/service/pubnub/PubnubStreamingService.java
+++ b/service-pubnub/src/main/java/info/bitrich/xchangestream/service/pubnub/PubnubStreamingService.java
@@ -15,7 +15,7 @@ import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import java.lang.UnsupportedOperationException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -108,5 +108,5 @@ public class PubnubStreamingService {
         return (pnStatusCategory == PNStatusCategory.PNConnectedCategory);
     }
 
-    public void useCompressedMessages(boolean compressedMessages) { throw new NotImplementedException(); }
+    public void useCompressedMessages(boolean compressedMessages) { throw new UnsupportedOperationException(); }
 }

--- a/service-pubnub/src/main/java/info/bitrich/xchangestream/service/pubnub/PubnubStreamingService.java
+++ b/service-pubnub/src/main/java/info/bitrich/xchangestream/service/pubnub/PubnubStreamingService.java
@@ -15,6 +15,7 @@ import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -106,4 +107,6 @@ public class PubnubStreamingService {
     public boolean isAlive() {
         return (pnStatusCategory == PNStatusCategory.PNConnectedCategory);
     }
+
+    public void useCompressedMessages(boolean compressedMessages) { throw new NotImplementedException(); }
 }

--- a/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
+++ b/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
@@ -92,5 +92,5 @@ public class PusherStreamingService {
         return pusher.getConnection().getState() == ConnectionState.CONNECTED;
     }
 
-    public void useCompressedMessages(boolean compressedMessages) { throw new NotImplementedException(); }
+    public void useCompressedMessages(boolean compressedMessages) { throw new UnsupportedOperationException(); }
 }

--- a/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
+++ b/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
@@ -11,6 +11,7 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.Collections;
 import java.util.List;
@@ -90,4 +91,6 @@ public class PusherStreamingService {
     public boolean isSocketOpen() {
         return pusher.getConnection().getState() == ConnectionState.CONNECTED;
     }
+
+    public void useCompressedMessages(boolean compressedMessages) { throw new NotImplementedException(); }
 }

--- a/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
+++ b/service-pusher/src/main/java/info/bitrich/xchangestream/service/pusher/PusherStreamingService.java
@@ -11,7 +11,6 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.Collections;
 import java.util.List;

--- a/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
+++ b/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
@@ -7,6 +7,7 @@ import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.subjects.BehaviorSubject;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 import ws.wamp.jawampa.PubSubData;
 import ws.wamp.jawampa.WampClient;
 import ws.wamp.jawampa.WampClient.State;
@@ -83,4 +84,6 @@ public class WampStreamingService {
         // WampClient was initiated with infinite reconnects attempts, so we can just always return 'true'
         return !((BehaviorSubject<State>) client.statusChanged()).hasCompleted();
     }
+
+    public void useCompressedMessages(boolean compressedMessages) { throw new NotImplementedException(); }
 }

--- a/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
+++ b/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
@@ -85,5 +85,5 @@ public class WampStreamingService {
         return !((BehaviorSubject<State>) client.statusChanged()).hasCompleted();
     }
 
-    public void useCompressedMessages(boolean compressedMessages) { throw new NotImplementedException(); }
+    public void useCompressedMessages(boolean compressedMessages) { throw new UnsupportedOperationException(); }
 }

--- a/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
+++ b/service-wamp/src/main/java/info/bitrich/xchangestream/service/wamp/WampStreamingService.java
@@ -7,7 +7,6 @@ import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.subjects.BehaviorSubject;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 import ws.wamp.jawampa.PubSubData;
 import ws.wamp.jawampa.WampClient;
 import ws.wamp.jawampa.WampClient.State;

--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -87,5 +87,8 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
+
 }
 

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingExchange.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingExchange.java
@@ -53,4 +53,8 @@ public class BitfinexStreamingExchange extends BitfinexExchange implements Strea
     public StreamingMarketDataService getStreamingMarketDataService() {
         return streamingMarketDataService;
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
+
 }

--- a/xchange-bitflyer/src/main/java/info/bitrich/xchangestream/bitflyer/BitflyerStreamingExchange.java
+++ b/xchange-bitflyer/src/main/java/info/bitrich/xchangestream/bitflyer/BitflyerStreamingExchange.java
@@ -9,7 +9,6 @@ import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.bitflyer.BitflyerExchange;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import si.mazi.rescu.SynchronizedValueFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * Created by Lukas Zaoralek on 14.11.17.

--- a/xchange-bitflyer/src/main/java/info/bitrich/xchangestream/bitflyer/BitflyerStreamingExchange.java
+++ b/xchange-bitflyer/src/main/java/info/bitrich/xchangestream/bitflyer/BitflyerStreamingExchange.java
@@ -7,7 +7,9 @@ import info.bitrich.xchangestream.service.pubnub.PubnubStreamingService;
 import io.reactivex.Completable;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.bitflyer.BitflyerExchange;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import si.mazi.rescu.SynchronizedValueFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * Created by Lukas Zaoralek on 14.11.17.
@@ -59,5 +61,8 @@ public class BitflyerStreamingExchange extends BitflyerExchange implements Strea
     public boolean isAlive() {
         return streamingService.isAlive();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }
 

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
@@ -57,4 +57,7 @@ public class BitmexStreamingExchange extends BitmexExchange implements Streaming
     public boolean isAlive() {
         return streamingService.isSocketOpen();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingService.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingService.java
@@ -14,25 +14,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.bitmex.dto.BitmexWebSocketSubscriptionMessage;
 import info.bitrich.xchangestream.bitmex.dto.BitmexWebSocketTransaction;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
-import info.bitrich.xchangestream.service.netty.WebSocketClientHandler;
-import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.http.DefaultHttpHeaders;
-import io.netty.handler.codec.http.HttpClientCodec;
-import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
-import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
-import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.reactivex.Completable;
 import io.reactivex.Observable;
 
 /**
@@ -46,85 +27,6 @@ public class BitmexStreamingService extends JsonNettyStreamingService {
         super(apiUrl, Integer.MAX_VALUE);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
-
-    @Override
-	 public Completable connect() {
-      return Completable.create(completable -> {
-        try {
-            LOG.info("Connecting to {}://{}:{}{}", uri.getScheme(), uri.getHost(), uri.getPort(), uri.getPath());
-            String scheme = uri.getScheme() == null ? "ws" : uri.getScheme();
-
-            String host = uri.getHost();
-            if (host == null) {
-                throw new IllegalArgumentException("Host cannot be null.");
-            }
-
-            final int port;
-            if (uri.getPort() == -1) {
-                if ("ws".equalsIgnoreCase(scheme)) {
-                    port = 80;
-                } else if ("wss".equalsIgnoreCase(scheme)) {
-                    port = 443;
-                } else {
-                    port = -1;
-                }
-            } else {
-                port = uri.getPort();
-            }
-
-            if (!"ws".equalsIgnoreCase(scheme) && !"wss".equalsIgnoreCase(scheme)) {
-                throw new IllegalArgumentException("Only WS(S) is supported.");
-            }
-
-            final boolean ssl = "wss".equalsIgnoreCase(scheme);
-            final SslContext sslCtx;
-            if (ssl) {
-                sslCtx = SslContextBuilder.forClient().build();
-            } else {
-                sslCtx = null;
-            }
-
-            final WebSocketClientHandler handler = getWebSocketClientHandler(WebSocketClientHandshakerFactory.newHandshaker(
-                    uri, WebSocketVersion.V13, null, true, new DefaultHttpHeaders(), maxFramePayloadLength),
-                    this::messageHandler);
-
-            Bootstrap b = new Bootstrap();
-            b.group(eventLoopGroup)
-                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, java.lang.Math.toIntExact(connectionTimeout.toMillis()))
-                    .channel(NioSocketChannel.class)
-                    .handler(new ChannelInitializer<SocketChannel>() {
-                        @Override
-                        protected void initChannel(SocketChannel ch) {
-                            ChannelPipeline p = ch.pipeline();
-                            if (sslCtx != null) {
-                                p.addLast(sslCtx.newHandler(ch.alloc(), host, port));
-                            }
-
-                            WebSocketClientExtensionHandler clientExtensionHandler = getWebSocketClientExtensionHandler();
-                            List<ChannelHandler> handlers = new ArrayList<>(4);
-                            handlers.add(new HttpClientCodec());
-                            handlers.add(WebSocketClientCompressionHandler.INSTANCE);
-                            handlers.add(new HttpObjectAggregator(8192));
-                            handlers.add(handler);
-                            if (clientExtensionHandler != null) handlers.add(clientExtensionHandler);
-                            p.addLast(handlers.toArray(new ChannelHandler[handlers.size()]));
-                        }
-                    });
-
-            b.connect(uri.getHost(), port).addListener((ChannelFuture future) -> {
-                webSocketChannel = future.channel();
-                if (future.isSuccess()) {
-                    handler.handshakeFuture().addListener(f -> completable.onComplete());
-                } else {
-                    completable.onError(future.cause());
-                }
-
-            });
-        } catch (Exception throwable) {
-            completable.onError(throwable);
-        }
-    });
-	 }
 
 	 @Override
     protected void handleMessage(JsonNode message) {

--- a/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingExchange.java
+++ b/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingExchange.java
@@ -7,7 +7,6 @@ import info.bitrich.xchangestream.service.pusher.PusherStreamingService;
 import io.reactivex.Completable;
 import org.knowm.xchange.bitstamp.BitstampExchange;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class BitstampStreamingExchange extends BitstampExchange implements StreamingExchange {
     private static final String API_KEY = "de504dc5763aeef9ff52";

--- a/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingExchange.java
+++ b/xchange-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/BitstampStreamingExchange.java
@@ -6,6 +6,8 @@ import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.service.pusher.PusherStreamingService;
 import io.reactivex.Completable;
 import org.knowm.xchange.bitstamp.BitstampExchange;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class BitstampStreamingExchange extends BitstampExchange implements StreamingExchange {
     private static final String API_KEY = "de504dc5763aeef9ff52";
@@ -42,4 +44,7 @@ public class BitstampStreamingExchange extends BitstampExchange implements Strea
     public boolean isAlive() {
         return this.streamingService.isSocketOpen();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }

--- a/xchange-coinmate/src/main/java/info/bitrich/xchange/coinmate/CoinmateStreamingExchange.java
+++ b/xchange-coinmate/src/main/java/info/bitrich/xchange/coinmate/CoinmateStreamingExchange.java
@@ -6,6 +6,8 @@ import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.service.pusher.PusherStreamingService;
 import io.reactivex.Completable;
 import org.knowm.xchange.coinmate.CoinmateExchange;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class CoinmateStreamingExchange extends CoinmateExchange implements StreamingExchange {
     private static final String API_KEY = "af76597b6b928970fbb0";
@@ -42,4 +44,7 @@ public class CoinmateStreamingExchange extends CoinmateExchange implements Strea
     public boolean isAlive() {
         return streamingService.isSocketOpen();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }

--- a/xchange-coinmate/src/main/java/info/bitrich/xchange/coinmate/CoinmateStreamingExchange.java
+++ b/xchange-coinmate/src/main/java/info/bitrich/xchange/coinmate/CoinmateStreamingExchange.java
@@ -7,7 +7,6 @@ import info.bitrich.xchangestream.service.pusher.PusherStreamingService;
 import io.reactivex.Completable;
 import org.knowm.xchange.coinmate.CoinmateExchange;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class CoinmateStreamingExchange extends CoinmateExchange implements StreamingExchange {
     private static final String API_KEY = "af76597b6b928970fbb0";

--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
@@ -7,6 +7,7 @@ import info.bitrich.xchangestream.service.netty.WebSocketClientHandler;
 import io.reactivex.Completable;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.gdax.GDAXExchange;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * GDAX Streaming Exchange. Connects to live WebSocket feed.
@@ -69,4 +70,7 @@ public class GDAXStreamingExchange extends GDAXExchange implements StreamingExch
     public boolean isAlive() {
         return streamingService != null && streamingService.isSocketOpen();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }

--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
@@ -7,7 +7,6 @@ import info.bitrich.xchangestream.service.netty.WebSocketClientHandler;
 import io.reactivex.Completable;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.gdax.GDAXExchange;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * GDAX Streaming Exchange. Connects to live WebSocket feed.

--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingExchange.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingExchange.java
@@ -5,6 +5,7 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.gemini.v1.GeminiExchange;
 
 /**
@@ -45,4 +46,7 @@ public class GeminiStreamingExchange extends GeminiExchange implements Streaming
     public boolean isAlive() {
         return streamingService.isAlive();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { throw new NotYetImplementedForExchangeException(); }
 }

--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingExchange.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingExchange.java
@@ -5,6 +5,7 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.Completable;
 import org.knowm.xchange.okcoin.OkCoinExchange;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class OkCoinStreamingExchange extends OkCoinExchange implements StreamingExchange {
     private static final String API_URI = "wss://real.okcoin.com:10440/websocket";
@@ -45,4 +46,7 @@ public class OkCoinStreamingExchange extends OkCoinExchange implements Streaming
     public StreamingMarketDataService getStreamingMarketDataService() {
         return streamingMarketDataService;
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }

--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingExchange.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingExchange.java
@@ -5,7 +5,6 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.Completable;
 import org.knowm.xchange.okcoin.OkCoinExchange;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class OkCoinStreamingExchange extends OkCoinExchange implements StreamingExchange {
     private static final String API_URI = "wss://real.okcoin.com:10440/websocket";

--- a/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingExchange.java
+++ b/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingExchange.java
@@ -5,6 +5,7 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.service.wamp.WampStreamingService;
 import io.reactivex.Completable;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.poloniex.PoloniexExchange;
 
 public class PoloniexStreamingExchange extends PoloniexExchange implements StreamingExchange {
@@ -43,4 +44,7 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
     public boolean isAlive() {
         return streamingService.isSocketOpen();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }

--- a/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
+++ b/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
@@ -10,6 +10,7 @@ import io.reactivex.Completable;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.poloniex.PoloniexExchange;
 
 import java.io.IOException;
@@ -89,4 +90,7 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
     public boolean isAlive() {
         return streamingService.isSocketOpen();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
@@ -30,4 +30,12 @@ public interface StreamingExchange extends Exchange {
      * Returns service that can be used to access market data.
      */
     StreamingMarketDataService getStreamingMarketDataService();
+
+    /**
+     * Set whether or not to enable compression handler.
+     *
+     * @param compressedMessages Defaults to false
+     */
+    void useCompressedMessages(boolean compressedMessages);
+
 }

--- a/xchange-wex/src/main/java/info/bitrich/xchangestream/wex/WexStreamingExchange.java
+++ b/xchange-wex/src/main/java/info/bitrich/xchangestream/wex/WexStreamingExchange.java
@@ -5,6 +5,7 @@ import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.service.pusher.PusherStreamingService;
 import io.reactivex.Completable;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.wex.v3.WexExchange;
 
 /**
@@ -46,4 +47,7 @@ public class WexStreamingExchange extends WexExchange implements StreamingExchan
     public boolean isAlive() {
         return this.streamingService.isSocketOpen();
     }
+
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }


### PR DESCRIPTION
some exchange websockets (ie. Bitmex Testnet) return compressed messages.  this has caused some exchanges to break from bad handshakes caused by the extension handlers for permessage-deflate.

this pr will allow you to optionally call exchange.useCompressedMessages(true) before calling connect() if you need to have the extension handlers added in your specific case