### PR TITLE
Fix build

### DIFF
--- a/xchange-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/HitbtcStreamingExchange.java
+++ b/xchange-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/HitbtcStreamingExchange.java
@@ -53,4 +53,7 @@ public class HitbtcStreamingExchange extends HitbtcExchange implements Streaming
     public StreamingMarketDataService getStreamingMarketDataService() {
         return streamingMarketDataService;
     }
+    
+    @Override
+    public void useCompressedMessages(boolean compressedMessages) { streamingService.useCompressedMessages(compressedMessages); }
 }


### PR DESCRIPTION
Fix development branch build failure 
`info.bitrich.xchangestream.hitbtc.HitbtcStreamingExchange is not abstract and does not override abstract method useCompressedMessages(boolean) in info.bitrich.xchangestream.core.StreamingExchange`

[Travis build error](https://travis-ci.org/bitrich-info/xchange-stream/builds/360188943)

I am using [jitpack.io](https://jitpack.io/#bitrich-info/xchange-stream/develop-SNAPSHOT) and they have the same issue as travis too. [Jitpack build error]( https://jitpack.io/com/github/bitrich-info/xchange-stream/develop-xchange-stream-parent-4.3.2-g71dbb8a-4/build.log)

I want to use the latest fix done on XChange Stream Binance code, I use this maven code to load a specific commit from develop branch, but then Jitpack cannot compile it. Also the current Travis build you set up doesn't build on develop branch. 
```xml
<repositories>
	<repository>
		<id>jitpack.io</id>
		<url>https://jitpack.io</url>
	</repository>
</repositories>
<dependencies>
	<dependency>
		<groupId>com.github.bitrich-info</groupId>
		<artifactId>xchange-stream</artifactId>
		<version>71dbb8a16ae258768ed0165566bcced156fc5310</version> <!-- Used with jitpack, put a commit id -->
	</dependency>
<dependencies>
```