### PR TITLE
Fix Binance Symbol To Currency Pair

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     </repositories>
 
     <properties>
-        <xchange.version>4.3.3</xchange.version>
+        <xchange.version>4.3.5</xchange.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/dto/ProductBinanceWebSocketTransaction.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/dto/ProductBinanceWebSocketTransaction.java
@@ -1,6 +1,7 @@
 package info.bitrich.xchangestream.binance.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.binance.BinanceAdapters;
 import org.knowm.xchange.currency.CurrencyPair;
 
 public class ProductBinanceWebSocketTransaction extends BaseBinanceWebSocketTransaction {
@@ -12,7 +13,7 @@ public class ProductBinanceWebSocketTransaction extends BaseBinanceWebSocketTran
             @JsonProperty("E") String eventTime,
             @JsonProperty("s") String symbol) {
         super(eventType, eventTime);
-        currencyPair = new CurrencyPair(symbol.substring(0, 3), symbol.substring(3, 6));
+        currencyPair = BinanceAdapters.adaptSymbol(symbol);
     }
 
     public CurrencyPair getCurrencyPair() {

--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/dto/TickerBinanceWebsocketTransaction.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/dto/TickerBinanceWebsocketTransaction.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
 
+import org.knowm.xchange.binance.BinanceAdapters;
 import org.knowm.xchange.binance.dto.marketdata.BinanceTicker24h;
 
 public class TickerBinanceWebsocketTransaction extends ProductBinanceWebSocketTransaction {
@@ -57,7 +58,8 @@ public class TickerBinanceWebsocketTransaction extends ProductBinanceWebSocketTr
                 closeTime,
                 firstId,
                 lastId,
-                count);
+                count,
+                BinanceAdapters.toSymbol(currencyPair));
         ticker.setCurrencyPair(currencyPair);
     }
 

--- a/xchange-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingMarketDataServiceTest.java
+++ b/xchange-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingMarketDataServiceTest.java
@@ -41,16 +41,18 @@ public class OkCoinStreamingMarketDataServiceTest {
 
         when(okCoinStreamingService.subscribeChannel(any())).thenReturn(Observable.just(jsonNode));
 
+        Date timestamp = new Date(1484602135246L);
+
         List<LimitOrder> bids = new ArrayList<>();
-        bids.add(new LimitOrder(Order.OrderType.BID, new BigDecimal("0.922"), CurrencyPair.BTC_USD, null, null, new BigDecimal("819.9")));
-        bids.add(new LimitOrder(Order.OrderType.BID, new BigDecimal("0.085"), CurrencyPair.BTC_USD, null, null, new BigDecimal("818.63")));
+        bids.add(new LimitOrder(Order.OrderType.BID, new BigDecimal("0.922"), CurrencyPair.BTC_USD, null, timestamp, new BigDecimal("819.9")));
+        bids.add(new LimitOrder(Order.OrderType.BID, new BigDecimal("0.085"), CurrencyPair.BTC_USD, null, timestamp, new BigDecimal("818.63")));
 
         List<LimitOrder> asks = new ArrayList<>();
-        asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("0.035"), CurrencyPair.BTC_USD, null, null, new BigDecimal("821.6")));
-        asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("5.18"), CurrencyPair.BTC_USD, null, null, new BigDecimal("821.65")));
-        asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("2.89"), CurrencyPair.BTC_USD, null, null, new BigDecimal("821.7")));
+        asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("0.035"), CurrencyPair.BTC_USD, null, timestamp, new BigDecimal("821.6")));
+        asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("5.18"), CurrencyPair.BTC_USD, null, timestamp, new BigDecimal("821.65")));
+        asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("2.89"), CurrencyPair.BTC_USD, null, timestamp, new BigDecimal("821.7")));
 
-        OrderBook expected = new OrderBook(new Date(1484602135246L), asks, bids);
+        OrderBook expected = new OrderBook(timestamp, asks, bids);
 
         // Call get order book observable
         TestObserver<OrderBook> test = marketDataService.getOrderBook(CurrencyPair.BTC_USD).test();


### PR DESCRIPTION
Binance symbol mapping to currency pair was wrong.
E.g. BTC/USDT was transformed into btcusd instead of btcusdt. Because of this I was not able to listen some currency pairs orderbooks: all currencies with symbols of more than 3 characters were failing (USDT, STEEM, etc.)

I used the function BinanceAdapters.adaptSymbol() from XChange 4.3.5 to map a Binance symbol to a currency pair. I had to upgrade XChange version + fix a test from OK Coin after upgrade to XChange 4.3.5