### PR TITLE
HITBTC doesn't update orderbook

### DIFF
--- a/xchange-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
+++ b/xchange-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
@@ -7,7 +7,6 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static java.math.BigDecimal.ZERO;
 import static java.util.Collections.reverseOrder;
 
 /**
@@ -27,11 +26,15 @@ public class HitbtcWebSocketOrderBook {
         this.bids = new TreeMap<>(reverseOrder(BigDecimal::compareTo));
 
         for (HitbtcOrderLimit orderBookItem : orderbookTransaction.getParams().getAsk()) {
-            asks.put(orderBookItem.getPrice(), orderBookItem);
+            if (orderBookItem.getSize().signum() != 0) {
+                asks.put(orderBookItem.getPrice(), orderBookItem);
+            }
         }
 
         for (HitbtcOrderLimit orderBookItem : orderbookTransaction.getParams().getBid()) {
-            bids.put(orderBookItem.getPrice(), orderBookItem);
+            if (orderBookItem.getSize().signum() != 0) {
+                bids.put(orderBookItem.getPrice(), orderBookItem);
+            }
         }
 
         sequence = orderbookTransaction.getParams().getSequence();
@@ -59,10 +62,10 @@ public class HitbtcWebSocketOrderBook {
     }
 
     private void updateOrderBookItems(HitbtcOrderLimit[] itemsToUpdate, Map<BigDecimal, HitbtcOrderLimit> localItems) {
-        for (HitbtcOrderLimit askToUpdate : itemsToUpdate) {
-            localItems.remove(askToUpdate.getPrice());
-            if (!askToUpdate.getSize().equals(ZERO)) {
-                localItems.put(askToUpdate.getPrice(), askToUpdate);
+        for (HitbtcOrderLimit itemToUpdate : itemsToUpdate) {
+            localItems.remove(itemToUpdate.getPrice());
+            if (itemToUpdate.getSize().signum() != 0) {
+                localItems.put(itemToUpdate.getPrice(), itemToUpdate);
             }
         }
     }

--- a/xchange-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
+++ b/xchange-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
@@ -50,7 +50,7 @@ public class HitbtcWebSocketOrderBook {
     }
 
     public void updateOrderBook(HitbtcWebSocketOrderBookTransaction orderBookTransaction) {
-        if (orderBookTransaction.getParams().getSequence() > sequence) {
+        if (orderBookTransaction.getParams().getSequence() <= sequence) {
             return;
         }
         updateOrderBookItems(orderBookTransaction.getParams().getAsk(), asks);

--- a/xchange-hitbtc/src/test/java/info/bitrich/xchangestream/hitbtc/HitbtcStreamingMarketDataServiceTest.java
+++ b/xchange-hitbtc/src/test/java/info/bitrich/xchangestream/hitbtc/HitbtcStreamingMarketDataServiceTest.java
@@ -54,7 +54,6 @@ public class HitbtcStreamingMarketDataServiceTest {
 
         List<LimitOrder> asks = new ArrayList<>();
         asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("0.245"), CurrencyPair.BTC_EUR, null, null, new BigDecimal("0.054588")));
-        asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("0.000"), CurrencyPair.BTC_EUR, null, null, new BigDecimal("0.054590")));
         asks.add(new LimitOrder(Order.OrderType.ASK, new BigDecimal("2.784"), CurrencyPair.BTC_EUR, null, null, new BigDecimal("0.054591")));
 
         // Call get order book observable


### PR DESCRIPTION
Critical defect - HITBTC orderbook is not updated at all - only "snapshots" are taken into account.