### PR TITLE
support testnet of bitmex (http://testnet.bitmex.com/)

### DIFF
--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
@@ -21,6 +21,10 @@ public class BitmexStreamingExchange extends BitmexExchange implements Streaming
         this.streamingService = new BitmexStreamingService(API_URI);
     }
 
+    protected BitmexStreamingExchange(BitmexStreamingService streamingService) {
+        this.streamingService = streamingService;
+    }
+
     @Override
     protected void initServices() {
         streamingMarketDataService = new BitmexStreamingMarketDataService(streamingService);

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexTestStreamingExchange.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexTestStreamingExchange.java
@@ -1,0 +1,10 @@
+package info.bitrich.xchangestream.bitmex;
+
+public class BitmexTestStreamingExchange extends BitmexStreamingExchange {
+
+    private static final String API_URI = "wss://testnet.bitmex.com/realtime";
+
+    public BitmexTestStreamingExchange() {
+        super(new BitmexStreamingService(API_URI));
+    }
+}


### PR DESCRIPTION
Add support for the test net of bitmex (http://testnet.bitmex.com/), which can be used for grayscale testing.
We are developing quantitative trading systems upon xchange-streaming and xchange. Grayscale testing is an important part in the development of quantitative trading systems.

By the way, seeing the 'MAINTAINER WANTED' message on the homepage, we are very willing to contribute to this project and help you to maintain it.