### PR TITLE
add support for okex futures trading

### DIFF
--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkExFuturesStreamingExchange.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkExFuturesStreamingExchange.java
@@ -1,0 +1,11 @@
+package info.bitrich.xchangestream.okcoin;
+
+public class OkExFuturesStreamingExchange extends OkExStreamingExchange {
+
+    private static final String API_URI = "wss://real.okex.com:10440/websocket/okexapi";
+
+    public OkExFuturesStreamingExchange() {
+        super(API_URI);
+    }
+}
+

--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkExStreamingExchange.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkExStreamingExchange.java
@@ -10,7 +10,7 @@ public class OkExStreamingExchange extends OkCoinStreamingExchange {
         super(new OkCoinStreamingService(API_URI));
     }
 
-    public OkExStreamingExchange(String api_url) {
-        super(new OkCoinStreamingService(api_url));
+    public OkExStreamingExchange(String apiUrl) {
+        super(new OkCoinStreamingService(apiUrl));
     }
 }

--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkExStreamingExchange.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkExStreamingExchange.java
@@ -9,4 +9,8 @@ public class OkExStreamingExchange extends OkCoinStreamingExchange {
     public OkExStreamingExchange() {
         super(new OkCoinStreamingService(API_URI));
     }
+
+    public OkExStreamingExchange(String api_url) {
+        super(new OkCoinStreamingService(api_url));
+    }
 }

--- a/xchange-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExFuturesManualExample.java
+++ b/xchange-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExFuturesManualExample.java
@@ -1,0 +1,38 @@
+package info.bitrich.xchangestream.okcoin;
+
+import info.bitrich.xchangestream.core.StreamingExchange;
+import info.bitrich.xchangestream.core.StreamingExchangeFactory;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.okcoin.FuturesContract;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OkExFuturesManualExample {
+    private static final Logger LOG = LoggerFactory.getLogger(OkExManualExample.class);
+
+    public static void main(String[] args) {
+        StreamingExchange exchange = StreamingExchangeFactory.INSTANCE.createExchange(OkExFuturesManualExample.class.getName());
+        exchange.connect().blockingAwait();
+
+        exchange.getStreamingMarketDataService().getOrderBook(CurrencyPair.BTC_USD, FuturesContract.Quarter).subscribe(orderBook -> {
+            LOG.info("First ask: {}", orderBook.getAsks().get(0));
+            LOG.info("First bid: {}", orderBook.getBids().get(0));
+        }, throwable -> LOG.error("ERROR in getting order book: ", throwable));
+
+        exchange.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD, FuturesContract.Quarter).subscribe(ticker -> {
+            LOG.info("TICKER: {}", ticker);
+        }, throwable -> LOG.error("ERROR in getting ticker: ", throwable));
+
+        exchange.getStreamingMarketDataService().getTrades(CurrencyPair.BTC_USD, FuturesContract.Quarter).subscribe(trade -> {
+            LOG.info("TRADE: {}", trade);
+        }, throwable -> LOG.error("ERROR in getting trades: ", throwable));
+
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/xchange-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExFuturesManualExample.java
+++ b/xchange-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExFuturesManualExample.java
@@ -2,7 +2,6 @@ package info.bitrich.xchangestream.okcoin;
 
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
-import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.okcoin.FuturesContract;
 import org.slf4j.Logger;


### PR DESCRIPTION
Okex futures trading API's endpoint is different from normal trading, which is at wss://real.okex.com:10440/websocket/okexapi.
Here's the API specification: https://github.com/okcoin-okex/API-docs-OKEx.com/blob/master/API-For-Futures-EN/WebSocket%20API%20for%20FUTURES.md