### PR TITLE
fix the bug of multi-contract subscribe

### DIFF
--- a/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingMarketDataService.java
+++ b/xchange-okcoin/src/main/java/info/bitrich/xchangestream/okcoin/OkCoinStreamingMarketDataService.java
@@ -70,16 +70,17 @@ public class OkCoinStreamingMarketDataService implements StreamingMarketDataServ
                 channel = channel + "_" + args[1];
             }
         }
+        final String key=channel;
 
         return service.subscribeChannel(channel)
                 .map(s -> {
                     OkCoinOrderbook okCoinOrderbook;
-                    if (!orderbooks.containsKey(currencyPair)) {
+                    if (!orderbooks.containsKey(key)) {
                         OkCoinDepth okCoinDepth = mapper.treeToValue(s.get("data"), OkCoinDepth.class);
                         okCoinOrderbook = new OkCoinOrderbook(okCoinDepth);
-                        orderbooks.put(currencyPair, okCoinOrderbook);
+                        orderbooks.put(key, okCoinOrderbook);
                     } else {
-                        okCoinOrderbook = orderbooks.get(currencyPair);
+                        okCoinOrderbook = orderbooks.get(key);
                         if (s.get("data").has("asks")) {
                             if (s.get("data").get("asks").size() > 0) {
                                 BigDecimal[][] askLevels = mapper.treeToValue(s.get("data").get("asks"), BigDecimal[][].class);


### PR DESCRIPTION
The key of the orderbooks should contain the information of contract type.
The original code use the currencyPair and different contracts would use the same entry.