### PR TITLE
Initialise binance streaming order book from the fetch api

### DIFF
--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -38,7 +38,7 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
 
         ProductSubscription subscriptions = args[0];
         streamingService = createStreamingService(subscriptions);
-        streamingMarketDataService = new BinanceStreamingMarketDataService(streamingService);
+        streamingMarketDataService = new BinanceStreamingMarketDataService(streamingService, marketDataService);
         return streamingService.connect()
                 .doOnComplete(() -> streamingMarketDataService.openSubscriptions(subscriptions));
     }

--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
@@ -141,7 +141,7 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
 
                     OrderBook currentOrderBook = orderbooks.computeIfAbsent(currencyPair, pair -> {
                       try {
-                        return marketDataService.getOrderBook(pair);
+                        return marketDataService.getOrderBook(pair, 1000);
                       } catch (IOException e) {
                         LOG.error("Failed to fetch initial order book for " + pair);
                         return new OrderBook(null, new ArrayList<>(), new ArrayList<>());

--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
@@ -23,6 +23,7 @@ import org.knowm.xchange.dto.marketdata.OrderBookUpdate;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.service.marketdata.MarketDataService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,8 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
     private static final Logger LOG = LoggerFactory.getLogger(BinanceStreamingMarketDataService.class);
 
     private final BinanceStreamingService service;
+    private final MarketDataService marketDataService;
+
     private final Map<CurrencyPair, OrderBook> orderbooks = new HashMap<>();
 
     private final Map<CurrencyPair, Observable<BinanceTicker24h>> tickerSubscriptions = new HashMap<>();
@@ -48,8 +51,9 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
     private final ObjectMapper mapper = new ObjectMapper();
 
 
-    public BinanceStreamingMarketDataService(BinanceStreamingService service) {
+    public BinanceStreamingMarketDataService(BinanceStreamingService service, MarketDataService marketDataService) {
         this.service = service;
+        this.marketDataService = marketDataService;
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
@@ -135,8 +139,14 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
                 .map(transaction -> {
                     DepthBinanceWebSocketTransaction depth = transaction.getData();
 
-                    OrderBook currentOrderBook = orderbooks.computeIfAbsent(currencyPair, orderBook ->
-                            new OrderBook(null, new ArrayList<>(), new ArrayList<>()));
+                    OrderBook currentOrderBook = orderbooks.computeIfAbsent(currencyPair, pair -> {
+                      try {
+                        return marketDataService.getOrderBook(pair);
+                      } catch (IOException e) {
+                        LOG.error("Failed to fetch initial order book for " + pair);
+                        return new OrderBook(null, new ArrayList<>(), new ArrayList<>());
+                      }
+                    });
 
                     BinanceOrderbook ob = depth.getOrderBook();
                     ob.bids.forEach((key, value) -> currentOrderBook.update(new OrderBookUpdate(


### PR DESCRIPTION
As detailed at https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md, you can't start from an empty order book when using the incremental depth API; you need to call the relevant endpoint first. Without this fix, you only get an order book with the most recent changes.

Not 100% convinced about the approach.  This is what I did to resolve an immediate problem but the error handling is suspect in the extreme (I went for the "please don't fall over on my prod box" rather than "fail fast and fail quickly") and the incremental approach used by `OrderBook` isn't quite what Binance recommend (but should probably be OK).

Comments welcome.