### PR TITLE
[BitMex] Refactoring for performance

### DIFF
--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingMarketDataService.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingMarketDataService.java
@@ -13,10 +13,8 @@ import org.knowm.xchange.dto.marketdata.Trade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by Lukas Zaoralek on 13.11.17.
@@ -26,7 +24,7 @@ public class BitmexStreamingMarketDataService implements StreamingMarketDataServ
 
     private final BitmexStreamingService streamingService;
 
-    private final SortedMap<CurrencyPair, BitmexOrderbook> orderbooks = new TreeMap<>();
+    private final Map<CurrencyPair, BitmexOrderbook> orderbooks = new ConcurrentHashMap<>();
 
     public BitmexStreamingMarketDataService(BitmexStreamingService streamingService) {
         this.streamingService = streamingService;

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingService.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingService.java
@@ -23,11 +23,11 @@ import io.reactivex.Observable;
  */
 public class BitmexStreamingService extends JsonNettyStreamingService {
     private static final Logger LOG = LoggerFactory.getLogger(BitmexStreamingService.class);
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     public BitmexStreamingService(String apiUrl) {
         super(apiUrl, Integer.MAX_VALUE);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
 	 @Override
@@ -51,7 +51,7 @@ public class BitmexStreamingService extends JsonNettyStreamingService {
 
     public Observable<BitmexWebSocketTransaction> subscribeBitmexChannel(String channelName) {
         return subscribeChannel(channelName).map(s -> {
-            BitmexWebSocketTransaction transaction = mapper.readValue(s.toString(), BitmexWebSocketTransaction.class);
+            BitmexWebSocketTransaction transaction = mapper.treeToValue(s, BitmexWebSocketTransaction.class);
             return transaction;
         })
                 .share();
@@ -67,14 +67,12 @@ public class BitmexStreamingService extends JsonNettyStreamingService {
     @Override
     public String getSubscribeMessage(String channelName, Object... args) throws IOException {
         BitmexWebSocketSubscriptionMessage subscribeMessage = new BitmexWebSocketSubscriptionMessage("subscribe", new String[]{channelName});
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.writeValueAsString(subscribeMessage);
+        return mapper.writeValueAsString(subscribeMessage);
     }
 
     @Override
     public String getUnsubscribeMessage(String channelName) throws IOException {
         BitmexWebSocketSubscriptionMessage subscribeMessage = new BitmexWebSocketSubscriptionMessage("unsubscribe", new String[]{});
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.writeValueAsString(subscribeMessage);
+        return mapper.writeValueAsString(subscribeMessage);
     }
 }

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexMarketDataEvent.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexMarketDataEvent.java
@@ -11,6 +11,8 @@ import java.util.Date;
  * Created by Lukas Zaoralek on 13.11.17.
  */
 public class BitmexMarketDataEvent {
+    private static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
     protected String timestamp;
     protected String symbol;
 
@@ -34,8 +36,6 @@ public class BitmexMarketDataEvent {
     }
 
     public Date getDate() {
-        SimpleDateFormat formatter;
-        formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         Date date = null;
         try {
             date = formatter.parse(timestamp);

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexWebSocketTransaction.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexWebSocketTransaction.java
@@ -14,7 +14,8 @@ public class BitmexWebSocketTransaction {
     private final String table;
     private final String action;
     private final JsonNode data;
-    private final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     public BitmexWebSocketTransaction(@JsonProperty("table") String table,
                                       @JsonProperty("action") String action,
@@ -22,7 +23,6 @@ public class BitmexWebSocketTransaction {
         this.table = table;
         this.action = action;
         this.data = data;
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     public BitmexLimitOrder[] toBitmexOrderbookLevels() {
@@ -30,7 +30,7 @@ public class BitmexWebSocketTransaction {
         for (int i = 0; i < data.size(); i++) {
             JsonNode jsonLevel = data.get(i);
             try {
-                levels[i] = mapper.readValue(jsonLevel.toString(), BitmexLimitOrder.class); //TODO: no need toString
+                levels[i] = mapper.treeToValue(jsonLevel, BitmexLimitOrder.class);
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -47,7 +47,7 @@ public class BitmexWebSocketTransaction {
     public BitmexTicker toBitmexTicker() {
         BitmexTicker bitmexTicker = null;
         try {
-            bitmexTicker = mapper.readValue(data.get(0).toString(), BitmexTicker.class);
+            bitmexTicker = mapper.treeToValue(data.get(0), BitmexTicker.class);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -59,7 +59,7 @@ public class BitmexWebSocketTransaction {
         for (int i = 0; i < data.size(); i++) {
             JsonNode jsonTrade = data.get(i);
             try {
-                trades[i] = mapper.readValue(jsonTrade.toString(), BitmexTrade.class);
+                trades[i] = mapper.treeToValue(jsonTrade, BitmexTrade.class);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexWebSocketTransaction.java
+++ b/xchange-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexWebSocketTransaction.java
@@ -30,7 +30,7 @@ public class BitmexWebSocketTransaction {
         for (int i = 0; i < data.size(); i++) {
             JsonNode jsonLevel = data.get(i);
             try {
-                levels[i] = mapper.readValue(jsonLevel.toString(), BitmexLimitOrder.class);
+                levels[i] = mapper.readValue(jsonLevel.toString(), BitmexLimitOrder.class); //TODO: no need toString
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Issues on previous implemnentation
- use TreeMap as orderbook, the CPU load is heavy when subscribing on multiple CurrencyPairs
- BitmexOrderbook maintain two Map structure, which is redundant
 
Major changes
- Use ConcurrentHashMap to persist orderbook
- In BitmexOrderbook, combine the two maps into a single map, key is 'id', value is the entity
- Code refactoring on orderbook update logic, make it more clear
- Code refactoring on ObjectMapper usage