### PR TITLE
Fix Binance websockets getting disconnected every few minutes

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
@@ -10,6 +10,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
@@ -77,6 +78,9 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
         if (frame instanceof TextWebSocketFrame) {
             TextWebSocketFrame textFrame = (TextWebSocketFrame)frame;
             handler.onMessage(textFrame.text());
+        } else if (frame instanceof PingWebSocketFrame) {
+            LOG.info("WebSocket Client received ping"); // TODO drop to debug
+            ch.writeAndFlush(new PongWebSocketFrame());
         } else if (frame instanceof PongWebSocketFrame) {
             LOG.debug("WebSocket Client received pong");
         } else if (frame instanceof CloseWebSocketFrame) {

--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
@@ -79,7 +79,7 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
             TextWebSocketFrame textFrame = (TextWebSocketFrame)frame;
             handler.onMessage(textFrame.text());
         } else if (frame instanceof PingWebSocketFrame) {
-            LOG.info("WebSocket Client received ping"); // TODO drop to debug
+            LOG.debug("WebSocket Client received ping");
             ch.writeAndFlush(new PongWebSocketFrame());
         } else if (frame instanceof PongWebSocketFrame) {
             LOG.debug("WebSocket Client received pong");

--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
@@ -80,7 +80,7 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
             handler.onMessage(textFrame.text());
         } else if (frame instanceof PingWebSocketFrame) {
             LOG.debug("WebSocket Client received ping");
-            ch.writeAndFlush(new PongWebSocketFrame());
+            ch.writeAndFlush(new PongWebSocketFrame(frame.content().retain()));
         } else if (frame instanceof PongWebSocketFrame) {
             LOG.debug("WebSocket Client received pong");
         } else if (frame instanceof CloseWebSocketFrame) {


### PR DESCRIPTION
Binance [requires](https://support.binance.com/hc/en-us/articles/360004492232-API-Frequently-Asked-Questions-FAQ-#%E2%80%9Cwebsocketdrop%E2%80%9D) that pings on websockets are responded with a pong frame.

I've implemented this for all exchanges, since this should be the [standard behaviour](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#Pings_and_Pongs_The_Heartbeat_of_WebSockets).

I have tested with Binance (fixes the connection drops), GDAX and Bitfinex.