### PR TITLE
Default GDAX order book depth to 100

### DIFF
--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingMarketDataService.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingMarketDataService.java
@@ -1,6 +1,5 @@
 package info.bitrich.xchangestream.gdax;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.gdax.dto.GDAXWebSocketTransaction;
@@ -29,8 +28,8 @@ public class GDAXStreamingMarketDataService implements StreamingMarketDataServic
     private static final Logger LOG = LoggerFactory.getLogger(GDAXStreamingMarketDataService.class);
 
     private final GDAXStreamingService service;
-    private Map<CurrencyPair, SortedMap<BigDecimal, String>> bids = new HashMap<>();
-    private Map<CurrencyPair, SortedMap<BigDecimal, String>> asks = new HashMap<>();
+    private final Map<CurrencyPair, SortedMap<BigDecimal, String>> bids = new HashMap<>();
+    private final Map<CurrencyPair, SortedMap<BigDecimal, String>> asks = new HashMap<>();
 
     GDAXStreamingMarketDataService(GDAXStreamingService service) {
         this.service = service;
@@ -55,7 +54,7 @@ public class GDAXStreamingMarketDataService implements StreamingMarketDataServic
         final ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-        final int maxDepth = (args.length > 0 && args[0] instanceof Integer) ? (int) args[0] : 0;
+        final int maxDepth = (args.length > 0 && args[0] instanceof Integer) ? (int) args[0] : 100;
 
         Observable<GDAXWebSocketTransaction> subscribedChannel = service.subscribeChannel(channelName)
                 .map(s -> mapper.readValue(s.toString(), GDAXWebSocketTransaction.class));


### PR DESCRIPTION
GDAX/Coinbase Pro returns a complete order book by default, and returns them at such an obscene rate that `ObjectMapper` falls behind on most boxes I've tested.  Two things happen: `OutOfMemoryError`s (if you're running with a limited memory footprint) and socket disconnections.

This default of 100 matches the one coded into `BitfinexStreamingMarketDataService`.