### PR TITLE
GDAX: Use fresh auth credentials each time we reconnect

### DIFF
--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingExchange.java
@@ -31,6 +31,14 @@ public class GDAXStreamingExchange extends GDAXExchange implements StreamingExch
         if (args == null || args.length == 0)
             throw new UnsupportedOperationException("The ProductSubscription must be defined!");
         ExchangeSpecification exchangeSpec = getExchangeSpecification();
+        this.streamingService = new GDAXStreamingService(API_URI, () -> authData(exchangeSpec));
+        this.streamingMarketDataService = new GDAXStreamingMarketDataService(this.streamingService);
+        streamingService.subscribeMultipleCurrencyPairs(args);
+
+        return streamingService.connect();
+    }
+
+    private GDAXWebsocketAuthData authData(ExchangeSpecification exchangeSpec) {
         GDAXWebsocketAuthData authData = null;
         if ( exchangeSpec.getApiKey() != null ) {
             try {
@@ -42,11 +50,7 @@ public class GDAXStreamingExchange extends GDAXExchange implements StreamingExch
                             " websocket.  Will only receive public information via API", e);
             }
         }
-        this.streamingService = new GDAXStreamingService(API_URI, authData);
-        this.streamingMarketDataService = new GDAXStreamingMarketDataService(this.streamingService);
-        streamingService.subscribeMultipleCurrencyPairs(args);
-
-        return streamingService.connect();
+        return authData;
     }
 
     @Override

--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
@@ -3,14 +3,13 @@ package info.bitrich.xchangestream.gdax;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.knowm.xchange.gdax.dto.account.GDAXWebsocketAuthData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.gdax.dto.GDAXWebSocketSubscriptionMessage;
 import info.bitrich.xchangestream.gdax.netty.WebSocketClientCompressionAllowClientNoContextHandler;
@@ -28,11 +27,11 @@ public class GDAXStreamingService extends JsonNettyStreamingService {
     private static final String SHARE_CHANNEL_NAME = "ALL";
     private final Map<String, Observable<JsonNode>> subscriptions = new HashMap<>();
     private ProductSubscription product = null;
-    private GDAXWebsocketAuthData authData = null;
+    private final Supplier<GDAXWebsocketAuthData> authData;
 
     private WebSocketClientHandler.WebSocketMessageHandler channelInactiveHandler = null;
 
-    public GDAXStreamingService(String apiUrl,GDAXWebsocketAuthData authData) {
+    public GDAXStreamingService(String apiUrl, Supplier<GDAXWebsocketAuthData> authData) {
         super(apiUrl, Integer.MAX_VALUE);
         this.authData = authData;
     }
@@ -71,7 +70,7 @@ public class GDAXStreamingService extends JsonNettyStreamingService {
 
     @Override
     public String getSubscribeMessage(String channelName, Object... args) throws IOException {
-        GDAXWebSocketSubscriptionMessage subscribeMessage = new GDAXWebSocketSubscriptionMessage(SUBSCRIBE, product, authData);
+        GDAXWebSocketSubscriptionMessage subscribeMessage = new GDAXWebSocketSubscriptionMessage(SUBSCRIBE, product, authData.get());
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.writeValueAsString(subscribeMessage);
     }
@@ -79,7 +78,7 @@ public class GDAXStreamingService extends JsonNettyStreamingService {
     @Override
     public String getUnsubscribeMessage(String channelName) throws IOException {
         GDAXWebSocketSubscriptionMessage subscribeMessage =
-                new GDAXWebSocketSubscriptionMessage(UNSUBSCRIBE, new String[]{"level2", "matches", "ticker"}, authData);
+                new GDAXWebSocketSubscriptionMessage(UNSUBSCRIBE, new String[]{"level2", "matches", "ticker"}, authData.get());
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.writeValueAsString(subscribeMessage);
     }

--- a/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
+++ b/xchange-gdax/src/main/java/info/bitrich/xchangestream/gdax/GDAXStreamingService.java
@@ -10,6 +10,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.gdax.dto.GDAXWebSocketSubscriptionMessage;
 import info.bitrich.xchangestream.gdax.netty.WebSocketClientCompressionAllowClientNoContextHandler;


### PR DESCRIPTION
I spotted a bug during review of #160.  Details:

https://github.com/bitrich-info/xchange-stream/pull/160#issuecomment-423916976
https://github.com/bitrich-info/xchange-stream/pull/160#issuecomment-427557352

This fixes it.  It simply makes sure that fresh auth details are regenerated each time the authenticated websocket reconnects.