### PR TITLE
Improve bitfinex invalid symbol logging

### DIFF
--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingService.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingService.java
@@ -88,7 +88,7 @@ public class BitfinexStreamingService extends JsonNettyStreamingService {
                 subscribedChannels.remove(channelId);
             } else if (event.textValue().equals(ERROR)) {
                 if (message.get("code").asInt() == SUBSCRIPTION_FAILED) {
-                    LOG.error("Error with message: " + message.get("msg"));
+                    LOG.error("Error with message: " + message.get("symbol") + " " + message.get("msg"));
                     return;
                 }
                 super.handleError(message, new ExchangeException("Error code: " + message.get("code").asText()));


### PR DESCRIPTION
Previously the error message was:Error with message: "symbol: invalid"
Now: Error with message: "FOO symbol: invalid" (easier to debug)

Closes #254