### PR TITLE
[Bitfinex] Fix trade signs

### DIFF
--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
@@ -48,7 +48,6 @@ public class BitfinexWebSocketTrade {
         } else {
             type = "buy";
         }
-
-        return new BitfinexTrade(price, amount, timestamp / 1000, "bitfinex", tradeId, type);
+        return new BitfinexTrade(price, amount.abs(), timestamp / 1000, "bitfinex", tradeId, type);
     }
 }


### PR DESCRIPTION
Trades from all other exchanges are presented with positive amounts (with the trade type indicating direction). On Bitfinex, sells were arriving negative and buys positive.