### PR TITLE
Connection rate limitation has been added for Bitfinex

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -105,7 +105,16 @@ public abstract class NettyStreamingService<T> {
         }
     }
 
+    /**
+     * Override this method in case need any pre-connection actions,
+     * like e.g. adding some throttle control for limiting too often opening connections
+     */
+    protected void beforeConnection() {
+        // not need any pre-connection actions by default
+    }
+
     public Completable connect() {
+        beforeConnection();
         return Completable.create(completable -> {
             try {
 

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexConnectionRateLimiter.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexConnectionRateLimiter.java
@@ -1,0 +1,52 @@
+package info.bitrich.xchangestream.bitfinex;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.concurrent.TimedSemaphore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Bitfinex does not allow opening more {@value BFX_CON_RATE_LIMIT_DEFAULT} socket connections per minute.
+ * If limit reached then the following exception will be is raised: <br/>
+ * <br/>WebSocket Client failed to connect. Invalid handshake response getStatus: 429 Too Many Requests
+ * <br/><br/>This class implements throttle control for limiting too often opening socket connections
+ */
+public class BitfinexConnectionRateLimiter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BitfinexConnectionRateLimiter.class);
+
+    public static final String BFX_CON_RATE_LIMIT = "bfxConRateLimit";
+    private static final Integer BFX_CON_RATE_LIMIT_DEFAULT = 15;
+
+    private static final TimedSemaphore timedSemaphore = new TimedSemaphore(1, TimeUnit.MINUTES, readLimitBfxConectionProperty());
+
+    /**
+     * Return number of allowed connections per minute for Bitfinex Socket API.
+     * Default value is {@value BFX_CON_RATE_LIMIT_DEFAULT}, but it can be overridden by system property {@value BFX_CON_RATE_LIMIT}
+     * @return
+     */
+    private static int readLimitBfxConectionProperty() {
+
+        String limitValue = System.getProperty(BFX_CON_RATE_LIMIT);
+        if (limitValue != null) {
+            if (StringUtils.isNumeric(limitValue)) {
+                return Integer.parseInt(limitValue);
+            } else {
+                LOG.warn("Invalid value of '{}' property: {}. It is ignored. Default value is used: {}", BFX_CON_RATE_LIMIT, limitValue, BFX_CON_RATE_LIMIT_DEFAULT);
+            }
+        }
+
+        return BFX_CON_RATE_LIMIT_DEFAULT;
+    }
+
+    public static void openConnectionRateLimit() {
+        try {
+            timedSemaphore.acquire();
+        } catch (InterruptedException e) {
+            // do nothing
+        }
+    }
+
+}

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingService.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingService.java
@@ -41,6 +41,11 @@ public class BitfinexStreamingService extends JsonNettyStreamingService {
     }
 
     @Override
+    protected void beforeConnection() {
+        BitfinexConnectionRateLimiter.openConnectionRateLimit();
+    }
+
+    @Override
     public void messageHandler(String message) {
         LOG.debug("Received message: {}", message);
         JsonNode jsonNode;

--- a/xchange-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/BitfinexManualExample.java
+++ b/xchange-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/BitfinexManualExample.java
@@ -22,6 +22,8 @@ public class BitfinexManualExample {
         StreamingExchange exchange = StreamingExchangeFactory.INSTANCE.createExchange(BitfinexStreamingExchange.class
                 .getName());
 
+        System.setProperty(BitfinexConnectionRateLimiter.BFX_CON_RATE_LIMIT, "5");
+
         ExchangeSpecification defaultExchangeSpecification = exchange.getDefaultExchangeSpecification();
 
 //        defaultExchangeSpecification.setShouldLoadRemoteMetaData(true);


### PR DESCRIPTION
We use Bitfinex Socket API and open socket for each currency pair. But sometimes our network becomes not stable and we gets a lot of socket reconnections at the time. Bitfinex allows only opening 15 sockets per minute and blocks our IP address in this case. And we gets error in the log:
`WebSocket Client failed to connect. Invalid handshake response getStatus: 429 Too Many Requests`
So I propose to add some throttle control of open connection operation.