### PR TITLE
Netty concurrency fixes, more consistent thread shutdown on errors

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
@@ -86,6 +86,8 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
         } else if (frame instanceof CloseWebSocketFrame) {
             LOG.info("WebSocket Client received closing");
             ch.close();
+        } else {
+            LOG.warn("Unknown WebSocket frame type received: {}", frame.getClass().getName());
         }
     }
 


### PR DESCRIPTION
Address #276, #278.

I've not been able to verify that this definitely prevents the thread leaks described in #278 since I've been unable to replicate them, but I've traced through and identified these additional places that a leak is possible,

Regarding #276, this is pretty much as described on the issue.