### PR TITLE
#356 Fix of the netty memory leak in case target exchange is broken

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -202,7 +202,6 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
                                         completable.onComplete();
                                     } else {
                                         webSocketChannel.disconnect().addListener(x -> {
-                                            scheduleReconnect();
                                             completable.onError(handshakeFuture.cause());
                                         });
                                     }


### PR DESCRIPTION
There is double resubscribing in case exchange socket has been broken