### PR TITLE
[coinbase-pro] Fix corruption of orderbooks & improve performance

### DIFF
--- a/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingAdapters.java
+++ b/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingAdapters.java
@@ -1,5 +1,11 @@
 package info.bitrich.xchangestream.coinbasepro;
 
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
 import org.knowm.xchange.coinbasepro.CoinbaseProAdapters;
 import org.knowm.xchange.coinbasepro.dto.trade.CoinbaseProOrder;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -7,12 +13,14 @@ import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
-
-import java.math.BigDecimal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketTransaction;
 
-class CoinbaseProStreamingAdapters {
+public class CoinbaseProStreamingAdapters {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CoinbaseProStreamingAdapters.class);
 
     /**
      * TODO this clearly isn't good enough. We need an initial snapshot that these
@@ -65,5 +73,51 @@ class CoinbaseProStreamingAdapters {
         } else {
             return OrderStatus.NEW;
         }
+    }
+
+    public static Date parseDate(final String rawDate) {
+
+      String modified;
+      if (rawDate.length() > 23) {
+        modified = rawDate.substring(0, 23);
+      } else if (rawDate.endsWith("Z")) {
+        switch (rawDate.length()) {
+          case 20:
+            modified = rawDate.substring(0, 19) + ".000";
+            break;
+          case 22:
+            modified = rawDate.substring(0, 21) + "00";
+            break;
+          case 23:
+            modified = rawDate.substring(0, 22) + "0";
+            break;
+          default:
+            modified = rawDate;
+            break;
+        }
+      } else {
+        switch (rawDate.length()) {
+          case 19:
+            modified = rawDate + ".000";
+            break;
+          case 21:
+            modified = rawDate + "00";
+            break;
+          case 22:
+            modified = rawDate + "0";
+            break;
+          default:
+            modified = rawDate;
+            break;
+        }
+      }
+      try {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.parse(modified);
+      } catch (ParseException e) {
+        LOG.warn("unable to parse rawDate={} modified={}", rawDate, modified, e);
+        return null;
+      }
     }
 }

--- a/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketTransaction.java
+++ b/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketTransaction.java
@@ -2,20 +2,26 @@ package info.bitrich.xchangestream.coinbasepro.dto;
 
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
+import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.knowm.xchange.coinbasepro.dto.marketdata.CoinbaseProProductBook;
 import org.knowm.xchange.coinbasepro.dto.marketdata.CoinbaseProProductStats;
 import org.knowm.xchange.coinbasepro.dto.marketdata.CoinbaseProProductTicker;
 import org.knowm.xchange.coinbasepro.dto.marketdata.CoinbaseProTrade;
 import org.knowm.xchange.coinbasepro.dto.trade.CoinbaseProFill;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.trade.LimitOrder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import info.bitrich.xchangestream.coinbasepro.CoinbaseProStreamingAdapters;
 
 /**
  * Domain object mapping a CoinbasePro web socket message.
@@ -114,7 +120,7 @@ public class CoinbaseProWebSocketTransaction {
         this.profileId = profileId;
     }
 
-    private String[][] CoinbaseProOrderBookChanges(String side, String[][] changes, SortedMap<BigDecimal, String> sideEntries,
+    private List<LimitOrder> coinbaseProOrderBookChanges(String side, OrderType orderType, CurrencyPair currencyPair, String[][] changes, SortedMap<BigDecimal, BigDecimal> sideEntries,
                                             int maxDepth) {
         if (changes.length == 0) {
             return null;
@@ -126,31 +132,32 @@ public class CoinbaseProWebSocketTransaction {
             }
 
             BigDecimal price = new BigDecimal(level[level.length - 2]);
-            String volume = level[level.length - 1];
+            BigDecimal volume = new BigDecimal(level[level.length - 1]);
             sideEntries.put(price, volume);
         }
 
-        List<String[]> levels = new ArrayList<>();
-        int currentDepth = 0;
-        for (Map.Entry<BigDecimal, String> level : sideEntries.entrySet()) {
-            if (maxDepth > 0 && currentDepth > maxDepth) continue;
-            String volume = level.getValue();
-            if (!volume.equals("0")) {
-                levels.add(new String[]{level.getKey().toString(), volume, "1"});
-                currentDepth++;
-            }
+        Stream<Entry<BigDecimal, BigDecimal>> stream = sideEntries.entrySet()
+              .stream()
+              .filter(level -> level.getValue().compareTo(BigDecimal.ZERO) != 0);
+        if (maxDepth != 0) {
+          stream = stream.limit(maxDepth);
         }
-
-        return levels.toArray(new String[levels.size()][]);
+        return stream.map(level -> new LimitOrder(
+              orderType,
+              level.getValue(),
+              currencyPair,
+              "0",
+              null,
+              level.getKey()))
+            .collect(Collectors.toList());
     }
 
-    public CoinbaseProProductBook toCoinbaseProProductBook(SortedMap<BigDecimal, String> bids, SortedMap<BigDecimal, String> asks,
-                                             int maxDepth) {
-        String[][] gdaxOrderBookBids = CoinbaseProOrderBookChanges("buy", changes != null ? changes : this.bids,
+    public OrderBook toOrderBook(SortedMap<BigDecimal, BigDecimal> bids, SortedMap<BigDecimal, BigDecimal> asks, int maxDepth, CurrencyPair currencyPair) {
+        List<LimitOrder> gdaxOrderBookBids = coinbaseProOrderBookChanges("buy", OrderType.BID, currencyPair, changes != null ? changes : this.bids,
                 bids, maxDepth);
-        String[][] gdaxOrderBookAsks = CoinbaseProOrderBookChanges("sell", changes != null ? changes : this.asks,
+        List<LimitOrder> gdaxOrderBookAsks = coinbaseProOrderBookChanges("sell", OrderType.ASK, currencyPair, changes != null ? changes : this.asks,
                 asks, maxDepth);
-        return new CoinbaseProProductBook((long) 0, gdaxOrderBookBids, gdaxOrderBookAsks);
+        return new OrderBook(time == null ? null : CoinbaseProStreamingAdapters.parseDate(time), gdaxOrderBookAsks, gdaxOrderBookBids, false);
     }
 
     public CoinbaseProProductTicker toCoinbaseProProductTicker() {

--- a/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketTransaction.java
+++ b/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketTransaction.java
@@ -2,6 +2,7 @@ package info.bitrich.xchangestream.coinbasepro.dto;
 
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
@@ -123,7 +124,11 @@ public class CoinbaseProWebSocketTransaction {
     private List<LimitOrder> coinbaseProOrderBookChanges(String side, OrderType orderType, CurrencyPair currencyPair, String[][] changes, SortedMap<BigDecimal, BigDecimal> sideEntries,
                                             int maxDepth) {
         if (changes.length == 0) {
-            return null;
+            return Collections.emptyList();
+        }
+
+        if (sideEntries == null) {
+            return Collections.emptyList();
         }
 
         for (String[] level : changes) {

--- a/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketTransaction.java
+++ b/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketTransaction.java
@@ -153,6 +153,7 @@ public class CoinbaseProWebSocketTransaction {
     }
 
     public OrderBook toOrderBook(SortedMap<BigDecimal, BigDecimal> bids, SortedMap<BigDecimal, BigDecimal> asks, int maxDepth, CurrencyPair currencyPair) {
+        // For efficiency, we go straight to XChange format
         List<LimitOrder> gdaxOrderBookBids = coinbaseProOrderBookChanges("buy", OrderType.BID, currencyPair, changes != null ? changes : this.bids,
                 bids, maxDepth);
         List<LimitOrder> gdaxOrderBookAsks = coinbaseProOrderBookChanges("sell", OrderType.ASK, currencyPair, changes != null ? changes : this.asks,


### PR DESCRIPTION
Noticed that I was getting zeros appearing in CBP orderbooks. This turned out to be due to concurrency issues with the use of `HashMap` to store the state.

Also made the `getOrderBook` method support any `Number` type for the max depth.

Finally fixed very high CPU usage caused by multiple format translations.