### PR TITLE
add nonceFactory back to KrakenStreamingExchange

### DIFF
--- a/xchange-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
+++ b/xchange-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
@@ -7,6 +7,7 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.kraken.KrakenExchange;
+import org.knowm.xchange.utils.nonce.CurrentTimeNonceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import si.mazi.rescu.SynchronizedValueFactory;

--- a/xchange-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
+++ b/xchange-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
@@ -22,6 +22,8 @@ public class KrakenStreamingExchange extends KrakenExchange implements Streaming
 
     private final KrakenStreamingService streamingService;
     private KrakenStreamingMarketDataService streamingMarketDataService;
+    
+    private final SynchronizedValueFactory<Long> nonceFactory = new CurrentTimeNonceFactory();
 
     public KrakenStreamingExchange() {
         this.streamingService = new KrakenStreamingService(API_URI);
@@ -50,7 +52,7 @@ public class KrakenStreamingExchange extends KrakenExchange implements Streaming
 
     @Override
     public SynchronizedValueFactory<Long> getNonceFactory() {
-        return null;
+        return nonceFactory;
     }
 
     @Override


### PR DESCRIPTION
a recent added getNonceFactory() { return null; } 
this had the unfortunatle side effect of failing KrakenExchange queries, when authentication is provided.
adding a second nonce factory (one for REST, plus one for Socket) allows both to work (when authenticated)