### PR TITLE
POM change: Java 9+ support (JAXB is missing now)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
             <artifactId>rxjava</artifactId>
             <version>2.2.13</version>
         </dependency>
+        
+   		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,12 +118,11 @@
             <version>2.2.13</version>
         </dependency>
         
-   		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.1</version>
-		</dependency>
-
+   	<dependency>
+	    <groupId>javax.xml.bind</groupId>
+	    <artifactId>jaxb-api</artifactId>
+	    <version>2.3.1</version>
+	</dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
JAXB has been removed from Java9 and higher. Need to add it as a library going forward. Quick change.