### PR TITLE
Add connection idle to public API

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -1,20 +1,5 @@
 package info.bitrich.xchangestream.service.netty;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.time.Duration;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import info.bitrich.xchangestream.service.ConnectableService;
 import info.bitrich.xchangestream.service.exception.NotConnectedException;
 import io.netty.bootstrap.Bootstrap;
@@ -35,9 +20,9 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
-import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -53,12 +38,27 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.subjects.PublishSubject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class NettyStreamingService<T> extends ConnectableService {
     private final Logger LOG = LoggerFactory.getLogger(this.getClass());
-    private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
-    private static final Duration DEFAULT_RETRY_DURATION = Duration.ofSeconds(15);
-    private static final int DEFAULT_IDLE_TIMEOUT = 0;
+
+    protected static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
+    protected static final Duration DEFAULT_RETRY_DURATION = Duration.ofSeconds(15);
+    protected static final int DEFAULT_IDLE_TIMEOUT = 0;
 
     private class Subscription {
         final ObservableEmitter<T> emitter;

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingExchange.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingExchange.java
@@ -2,10 +2,8 @@ package info.bitrich.xchangestream.bitfinex;
 
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
-
 import io.reactivex.Completable;
 import io.reactivex.Observable;
-
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.bitfinex.BitfinexExchange;
@@ -64,6 +62,11 @@ public class BitfinexStreamingExchange extends BitfinexExchange implements Strea
     @Override
     public Observable<Object> connectionSuccess() {
         return streamingService.subscribeConnectionSuccess();
+    }
+
+    @Override
+    public Observable<Object> connectionIdle() {
+        return streamingService.subscribeIdle();
     }
 
     @Override

--- a/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingService.java
+++ b/xchange-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingService.java
@@ -2,7 +2,6 @@ package info.bitrich.xchangestream.bitfinex;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import info.bitrich.xchangestream.bitfinex.dto.BitfinexAuthRequestStatus;
 import info.bitrich.xchangestream.bitfinex.dto.BitfinexWebSocketAuth;
 import info.bitrich.xchangestream.bitfinex.dto.BitfinexWebSocketAuthBalance;
@@ -13,23 +12,21 @@ import info.bitrich.xchangestream.bitfinex.dto.BitfinexWebSocketSubscriptionMess
 import info.bitrich.xchangestream.bitfinex.dto.BitfinexWebSocketUnSubscriptionMessage;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
-
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
-
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.bitfinex.service.BitfinexAdapters;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import si.mazi.rescu.SynchronizedValueFactory;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -45,8 +42,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.knowm.xchange.service.BaseParamsDigest.HMAC_SHA_384;
-
-import si.mazi.rescu.SynchronizedValueFactory;
 
 /**
  * Created by Lukas Zaoralek on 7.11.17.
@@ -96,7 +91,7 @@ public class BitfinexStreamingService extends JsonNettyStreamingService {
 
     public BitfinexStreamingService(String apiUrl,
                                     SynchronizedValueFactory<Long> nonceFactory) {
-        super(apiUrl, Integer.MAX_VALUE);
+        super(apiUrl, Integer.MAX_VALUE, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_RETRY_DURATION, 30);
         this.nonceFactory = nonceFactory;
     }
 

--- a/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
+++ b/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
@@ -75,6 +75,11 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
     }
 
     @Override
+    public Observable<Object> connectionIdle() {
+        return streamingService.subscribeIdle();
+    }
+
+    @Override
     public ExchangeSpecification getDefaultExchangeSpecification() {
         ExchangeSpecification spec = super.getDefaultExchangeSpecification();
         spec.setShouldLoadRemoteMetaData(false);

--- a/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingService.java
+++ b/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingService.java
@@ -30,7 +30,7 @@ public class PoloniexStreamingService extends JsonNettyStreamingService {
 
 
     public PoloniexStreamingService(String apiUrl) {
-        super(apiUrl, Integer.MAX_VALUE);
+        super(apiUrl, Integer.MAX_VALUE, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_RETRY_DURATION, 2);
     }
 
     @Override

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
@@ -81,6 +81,10 @@ public interface StreamingExchange extends Exchange {
         throw new NotYetImplementedForExchangeException();
     }
 
+    default Observable<Object> connectionIdle() {
+        throw new NotYetImplementedForExchangeException();
+    };
+
     /**
      * Returns service that can be used to access streaming market data.
      */


### PR DESCRIPTION
Timeout values:

Bitfinex documentation says heartbeat is sent each 5 seconds. When testing this, heartbeat was coming each 15 seconds.

Poloniex mentions heartbeat each second and I can confirm this.

I've multiplied the timeout values x2 to be sure there are no false alarms, so Bitfinex 30 seconds, Poloniex 2 seconds.