### PR TITLE
[CoinbasePro] orderbook - this bug again

### DIFF
--- a/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingMarketDataService.java
+++ b/xchange-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingMarketDataService.java
@@ -62,6 +62,9 @@ public class CoinbaseProStreamingMarketDataService implements StreamingMarketDat
                     if (s.getType().equals(SNAPSHOT)) {
                         bids.put(currencyPair, new TreeMap<>(java.util.Collections.reverseOrder()));
                         asks.put(currencyPair, new TreeMap<>());
+                    } else {
+                        bids.computeIfAbsent(currencyPair, k -> new TreeMap<>(java.util.Collections.reverseOrder()));
+                        asks.computeIfAbsent(currencyPair, k -> new TreeMap<>());
                     }
                     return s.toOrderBook(
                         bids.get(currencyPair),


### PR DESCRIPTION
When system is loaded, bids and asks do not always get created, and since there is no synchronization we arrive in getOrderBook with bids.get(cuurencyPair) & asks.get(cuurencyPair) = null and message.getType().equals(L2UPDATE)