### PR TITLE
Add getTickers for #124 and #98

### DIFF
--- a/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingMarketDataService.java
+++ b/xchange-poloniex/src/main/java/info/bitrich/xchangestream/poloniex/PoloniexStreamingMarketDataService.java
@@ -2,6 +2,7 @@ package info.bitrich.xchangestream.poloniex;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.collect.Sets;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.poloniex.utils.MinMaxPriorityQueueUtils;
 import info.bitrich.xchangestream.service.wamp.WampStreamingService;
@@ -90,6 +91,12 @@ public class PoloniexStreamingMarketDataService implements StreamingMarketDataSe
 
     @Override
     public Observable<Ticker> getTicker(CurrencyPair currencyPair, Object... args) {
+        return getTickers(currencyPair);
+    }
+
+    @Override
+    public Observable<Ticker> getTickers(CurrencyPair... args) {
+        HashSet<CurrencyPair> pairs = Sets.newHashSet(args);
         return streamingService.subscribeChannel("ticker")
                 .map(pubSubData -> {
                     PoloniexMarketData marketData = new PoloniexMarketData();
@@ -105,7 +112,7 @@ public class PoloniexStreamingMarketDataService implements StreamingMarketDataSe
                     PoloniexTicker ticker = new PoloniexTicker(marketData, PoloniexUtils.toCurrencyPair(pubSubData.arguments().get(0).asText()));
                     return PoloniexAdapters.adaptPoloniexTicker(ticker, ticker.getCurrencyPair());
                 })
-                .filter(ticker -> ticker.getCurrencyPair().equals(currencyPair));
+                .filter(ticker -> pairs.contains(ticker.getCurrencyPair()));
     }
 
     @Override

--- a/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
+++ b/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
@@ -8,6 +8,7 @@ import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -37,12 +38,13 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
     protected void initServices() {
         applyStreamingSpecification(getExchangeSpecification(), streamingService);
         super.initServices();
-        Map<CurrencyPair, Integer> currencyPairMap = getCurrencyPairMap();
-        streamingMarketDataService = new PoloniexStreamingMarketDataService(streamingService, currencyPairMap);
+        Pair<Map<CurrencyPair, Integer>, Map<Integer, CurrencyPair>> currencyPairMaps = getCurrencyPairMap();
+        streamingMarketDataService = new PoloniexStreamingMarketDataService(streamingService, currencyPairMaps);
     }
 
-    private Map<CurrencyPair, Integer> getCurrencyPairMap() {
+    private Pair<Map<CurrencyPair, Integer>, Map<Integer, CurrencyPair>> getCurrencyPairMap() {
         Map<CurrencyPair, Integer> currencyPairMap = new HashMap<>();
+        Map<Integer, CurrencyPair> currencyIdMap = new HashMap<>();
         final ObjectMapper mapper = StreamingObjectMapperHelper.getObjectMapper();
 
         try {
@@ -56,12 +58,14 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
                 String[] currencies = pairSymbol.split("_");
                 CurrencyPair currencyPair = new CurrencyPair(new Currency(currencies[1]), new Currency(currencies[0]));
                 currencyPairMap.put(currencyPair, Integer.valueOf(id));
+                currencyIdMap.put(Integer.valueOf(id), currencyPair);
+
             }
         } catch (IOException e) {
             e.printStackTrace();
         }
 
-        return currencyPairMap;
+        return Pair.of(currencyPairMap, currencyIdMap);
     }
 
     @Override

--- a/xchange-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
+++ b/xchange-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
@@ -13,7 +13,9 @@ public class PoloniexManualExample {
 
     public static void main(String[] args) throws Exception {
         CurrencyPair usdtBtc = new CurrencyPair(new Currency("BTC"), new Currency("USDT"));
-//        CertHelper.trustAllCerts();
+        CurrencyPair ltcbtc = new CurrencyPair(new Currency("LTC"), new Currency("BTC"));
+//
+        //        CertHelper.trustAllCerts();
         StreamingExchange exchange = StreamingExchangeFactory.INSTANCE.createExchange(PoloniexStreamingExchange.class.getName());
         ExchangeSpecification defaultExchangeSpecification = exchange.getDefaultExchangeSpecification();
 //        defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.SOCKS_PROXY_HOST, "localhost");
@@ -37,7 +39,7 @@ public class PoloniexManualExample {
             LOG.info("First bid: {}", orderBook.getBids().get(0));
         }, throwable -> LOG.error("ERROR in getting order book: ", throwable));
 
-        exchange.getStreamingMarketDataService().getTicker(usdtBtc).subscribe(ticker -> {
+        exchange.getStreamingMarketDataService().getTickers(usdtBtc, ltcbtc).subscribe(ticker -> {
             LOG.info("TICKER: {}", ticker);
         }, throwable -> LOG.error("ERROR in getting ticker: ", throwable));
 

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingMarketDataService.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingMarketDataService.java
@@ -7,6 +7,8 @@ import org.knowm.xchange.dto.marketdata.Trade;
 
 import io.reactivex.Observable;
 
+import java.util.Arrays;
+
 
 public interface StreamingMarketDataService {
     /**
@@ -37,6 +39,24 @@ public interface StreamingMarketDataService {
      * @return {@link Observable} that emits {@link Ticker} when exchange sends the update.
      */
     Observable<Ticker> getTicker(CurrencyPair currencyPair, Object... args);
+
+    /**
+     * Get all tickers on the exchange. This may not be supported on all Exchanges.
+     * Emits {@link info.bitrich.xchangestream.service.exception.NotConnectedException} When not connected to the WebSocket API.
+     *
+     * <p><strong>Warning:</strong> There are currently no guarantees
+     * that messages will not be skipped, or that any initial state
+     * message will be sent on connection.</p>
+     *
+     * @return {@link Observable} that emits {@link Ticker} when exchange sends the update.
+     */
+    default Observable<Ticker> getTickers(CurrencyPair... args) {
+        return Arrays.asList(args).stream()
+                .map(s -> getTicker(s))
+                .reduce(Observable::mergeWith)
+                .get();
+    }
+
 
     /**
      * Get the trades performed by the exchange.


### PR DESCRIPTION
Per tickets #98 and #124, it's been requested to allow for a single Observable that emits multiple (or all) currency pairs. This PR enhances the StreamingMarketData interface for all exchanges to support this with a new method: getTickers(CurrencyPair ...). Just pass it all the currencyPairs you are interested in, and on supported exchanges it will filter from a single stream, otherwise it will subscribe to all the tickers listed, and return a composite Observable that emits all the pairs requested.