### PR TITLE
Change Poloniex to have a single subscription for Ticker. Fixes #124 and #98

### DIFF
--- a/xchange-poloniex/pom.xml
+++ b/xchange-poloniex/pom.xml
@@ -25,11 +25,9 @@
             <artifactId>xchange-poloniex</artifactId>
             <version>${xchange.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
         </dependency>
     </dependencies>
 </project>

--- a/xchange-poloniex2/pom.xml
+++ b/xchange-poloniex2/pom.xml
@@ -25,5 +25,9 @@
             <artifactId>service-netty</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
+++ b/xchange-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
@@ -37,26 +37,25 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
     protected void initServices() {
         applyStreamingSpecification(getExchangeSpecification(), streamingService);
         super.initServices();
-        Map<CurrencyPair, Integer> currencyPairMap = getCurrencyPairMap();
+        Map<Integer, CurrencyPair> currencyPairMap = getCurrencyPairMap();
         streamingMarketDataService = new PoloniexStreamingMarketDataService(streamingService, currencyPairMap);
     }
 
-    private Map<CurrencyPair, Integer> getCurrencyPairMap() {
-        Map<CurrencyPair, Integer> currencyPairMap = new HashMap<>();
+    private Map<Integer, CurrencyPair> getCurrencyPairMap() {
+        Map<Integer, CurrencyPair> currencyPairMap = new HashMap<>();
         final ObjectMapper mapper = StreamingObjectMapperHelper.getObjectMapper();
 
         try {
             URL tickerUrl = new URL(TICKER_URL);
             JsonNode jsonRootTickers = mapper.readTree(tickerUrl);
             Iterator<String> pairSymbols = jsonRootTickers.fieldNames();
-            while (pairSymbols.hasNext()) {
-                String pairSymbol = pairSymbols.next();
+            pairSymbols.forEachRemaining(pairSymbol ->{
                 String id = jsonRootTickers.get(pairSymbol).get("id").toString();
-
                 String[] currencies = pairSymbol.split("_");
                 CurrencyPair currencyPair = new CurrencyPair(new Currency(currencies[1]), new Currency(currencies[0]));
-                currencyPairMap.put(currencyPair, Integer.valueOf(id));
-            }
+                currencyPairMap.put(Integer.valueOf(id), currencyPair);
+
+            });
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/xchange-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
+++ b/xchange-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
@@ -13,7 +13,9 @@ public class PoloniexManualExample {
 
     public static void main(String[] args) throws Exception {
         CurrencyPair usdtBtc = new CurrencyPair(new Currency("BTC"), new Currency("USDT"));
-//        CertHelper.trustAllCerts();
+        CurrencyPair ltcBtc = new CurrencyPair(new Currency("LTC"), new Currency("BTC"));
+//
+        //        CertHelper.trustAllCerts();
         StreamingExchange exchange = StreamingExchangeFactory.INSTANCE.createExchange(PoloniexStreamingExchange.class.getName());
         ExchangeSpecification defaultExchangeSpecification = exchange.getDefaultExchangeSpecification();
 //        defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.SOCKS_PROXY_HOST, "localhost");
@@ -31,7 +33,6 @@ public class PoloniexManualExample {
         exchange.connect().blockingAwait();
 
 
-
         exchange.getStreamingMarketDataService().getOrderBook(usdtBtc).subscribe(orderBook -> {
             LOG.info("First ask: {}", orderBook.getAsks().get(0));
             LOG.info("First bid: {}", orderBook.getBids().get(0));
@@ -40,6 +41,11 @@ public class PoloniexManualExample {
         exchange.getStreamingMarketDataService().getTicker(usdtBtc).subscribe(ticker -> {
             LOG.info("TICKER: {}", ticker);
         }, throwable -> LOG.error("ERROR in getting ticker: ", throwable));
+
+        exchange.getStreamingMarketDataService().getTicker(ltcBtc).subscribe(ticker -> {
+            LOG.info("TICKER: {}", ticker);
+        }, throwable -> LOG.error("ERROR in getting ticker: ", throwable));
+
 
         exchange.getStreamingMarketDataService().getTrades(usdtBtc).subscribe(trade -> {
             LOG.info("TRADE: {}", trade);


### PR DESCRIPTION
To better support #124 and #98, PoloniexStreamingMarketDataService has been changed to have a single subscription for Ticker which is then shared by all subscribers to the Ticker.

To get all the Tickers in a single observable, it is suggested the client create a list of all currencyPairs on the exchange, and use something like the following:

`Observable<Ticker> allTickers = Observable.fromIterable(currencyPairs).flatMap(pair -> streamingMarketDataService.getTicker(pair));`