### PR TITLE
[core] subscribeChannel unnecessary onError

### DIFF
--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -328,8 +328,8 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
             if (channels.remove(channelId) != null) {
                 try {
                     sendMessage(getUnsubscribeMessage(channelId));
-                } catch (Exception e) {
-                    // ignore
+                } catch (IOException e) {
+                    LOG.warn("Failed to unsubscribe channel: {}",channelId);
                 }
             }
         }).share();

--- a/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -312,7 +312,7 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
         LOG.info("Subscribing to channel {}", channelId);
 
         return Observable.<T>create(e -> {
-            if (webSocketChannel == null || !webSocketChannel.isOpen()) {
+            if (webSocketChannel == null) { // || !webSocketChannel.isOpen()) {
                 e.onError(new NotConnectedException());
             }
             channels.computeIfAbsent(channelId, cid -> {
@@ -326,7 +326,11 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
             });
         }).doOnDispose(() -> {
             if (channels.remove(channelId) != null) {
-                sendMessage(getUnsubscribeMessage(channelId));
+                try {
+                    sendMessage(getUnsubscribeMessage(channelId));
+                } catch (Exception e) {
+                    // ignore
+                }
             }
         }).share();
     }


### PR DESCRIPTION
It seems to me that subscribeChannel can succeed even if the socket is not open and sendMessage already checks if it is open.
doOnDispose is unprotected from IO Exception?