### PR TITLE
[BINANCE] Add specific param: use higher update frequency

### DIFF
--- a/xchange-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceTest.java
+++ b/xchange-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceTest.java
@@ -1,25 +1,41 @@
 package info.bitrich.xchangestream.binance;
 
 import info.bitrich.xchangestream.core.ProductSubscription;
-
+import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 import org.junit.Assert;
 import org.junit.Test;
+import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.CurrencyPair;
+
+import static info.bitrich.xchangestream.binance.BinanceStreamingExchange.USE_HIGHER_UPDATE_FREQUENCY;
 
 public class BinanceTest {
 
     @Test
     public void channelCreateUrlTest() {
+        BinanceStreamingExchange exchange = (BinanceStreamingExchange) StreamingExchangeFactory.INSTANCE
+                .createExchange(BinanceStreamingExchange.class.getName());
         ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
         builder.addTicker(CurrencyPair.BTC_USD).addTicker(CurrencyPair.DASH_BTC);
-        String buildSubscriptionStreams = BinanceStreamingExchange.buildSubscriptionStreams(builder.build());
+        String buildSubscriptionStreams = exchange.buildSubscriptionStreams(builder.build());
         Assert.assertEquals("btcusd@ticker/dashbtc@ticker", buildSubscriptionStreams);
 
         ProductSubscription.ProductSubscriptionBuilder builder2 = ProductSubscription.create();
         builder2.addTicker(CurrencyPair.BTC_USD).addTicker(CurrencyPair.DASH_BTC).addOrderbook(CurrencyPair.ETH_BTC);
-        String buildSubscriptionStreams2 = BinanceStreamingExchange.buildSubscriptionStreams(builder2.build());
+        String buildSubscriptionStreams2 = exchange.buildSubscriptionStreams(builder2.build());
         Assert.assertEquals("btcusd@ticker/dashbtc@ticker/ethbtc@depth", buildSubscriptionStreams2);
     }
 
-
+    @Test
+    public void channelCreateUrlWithUpdateFrequencyTest() {
+        ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
+        builder.addTicker(CurrencyPair.BTC_USD).addTicker(CurrencyPair.DASH_BTC).addOrderbook(CurrencyPair.ETH_BTC);
+        ExchangeSpecification spec = StreamingExchangeFactory.INSTANCE.createExchange(
+                BinanceStreamingExchange.class.getName()).getDefaultExchangeSpecification();
+        spec.setExchangeSpecificParametersItem(USE_HIGHER_UPDATE_FREQUENCY, true);
+        BinanceStreamingExchange exchange = (BinanceStreamingExchange) StreamingExchangeFactory.INSTANCE
+                .createExchange(spec);
+        String buildSubscriptionStreams = exchange.buildSubscriptionStreams(builder.build());
+        Assert.assertEquals("btcusd@ticker/dashbtc@ticker/ethbtc@depth@100ms", buildSubscriptionStreams);
+    }
 }


### PR DESCRIPTION
* Add exchange specific param to set update frequency (Binance_Orderbook_Use_Higher_Frequency). If set to true 100ms will be used as update frequency