### PR TITLE
[Gemini] Fix socket excessive close/reconnect

### DIFF
--- a/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiProductStreamingService.java
+++ b/xchange-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiProductStreamingService.java
@@ -3,6 +3,8 @@ package info.bitrich.xchangestream.gemini;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +20,7 @@ public class GeminiProductStreamingService extends JsonNettyStreamingService {
     private final CurrencyPair currencyPair;
 
     public GeminiProductStreamingService(String symbolUrl, CurrencyPair currencyPair) {
-        super(symbolUrl, Integer.MAX_VALUE);
+        super(symbolUrl, Integer.MAX_VALUE, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_RETRY_DURATION,15);
         this.currencyPair = currencyPair;
     }
 
@@ -40,5 +42,9 @@ public class GeminiProductStreamingService extends JsonNettyStreamingService {
     @Override
     public String getUnsubscribeMessage(String channelName) throws IOException {
         return null;
+    }
+    @Override
+    protected void handleIdle(ChannelHandlerContext ctx) {
+        ctx.writeAndFlush(new PingWebSocketFrame());
     }
 }


### PR DESCRIPTION
11:58:07.702[WARN ][opGroup-15-1][i.b.x.g.GeminiProductStreamingService] Resubscribing channels
11:58:08.703[INFO ][opGroup-16-1][i.b.x.s.n.WebSocketClientHandler] WebSocket Client connected! [id: 0x4fc02e39, L:/192.168.0.100:49178 - R:api.gemini.com/18.211.184.12:443]
11:58:08.703[WARN ][opGroup-16-1][i.b.x.g.GeminiProductStreamingService] Resubscribing channels
11:58:08.817[INFO ][opGroup-17-1][i.b.x.s.n.WebSocketClientHandler] WebSocket Client connected! [id: 0x41b1b382, L:/192.168.0.100:49185 - R:api.gemini.com/18.211.184.12:443]
11:58:08.818[WARN ][opGroup-17-1][i.b.x.g.GeminiProductStreamingService] Resubscribing channels