### PR TITLE
Making all online tests @Ignore to allow build to work with no Internet connection. Fixes #357

### DIFF
--- a/xchange-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceTest.java
+++ b/xchange-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceTest.java
@@ -3,6 +3,7 @@ package info.bitrich.xchangestream.binance;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -12,6 +13,7 @@ import static info.bitrich.xchangestream.binance.BinanceStreamingExchange.USE_HI
 public class BinanceTest {
 
     @Test
+    @Ignore
     public void channelCreateUrlTest() {
         BinanceStreamingExchange exchange = (BinanceStreamingExchange) StreamingExchangeFactory.INSTANCE
                 .createExchange(BinanceStreamingExchange.class.getName());
@@ -27,6 +29,7 @@ public class BinanceTest {
     }
 
     @Test
+    @Ignore
     public void channelCreateUrlWithUpdateFrequencyTest() {
         ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
         builder.addTicker(CurrencyPair.BTC_USD).addTicker(CurrencyPair.DASH_BTC).addOrderbook(CurrencyPair.ETH_BTC);

--- a/xchange-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexTest.java
+++ b/xchange-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexTest.java
@@ -8,6 +8,7 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
@@ -61,18 +62,21 @@ public class BitmexTest {
     }
 
     @Test
+    @Ignore
     public void shouldReceiveBooks() {
         Observable<OrderBook> orderBookObservable = streamingMarketDataService.getOrderBook(xbtUsd);
         awaitDataCount(orderBookObservable);
     }
 
     @Test
+    @Ignore
     public void shouldReceiveRawTickers() {
         Observable<BitmexTicker> rawTickerObservable = streamingMarketDataService.getRawTicker(xbtUsd);
         awaitDataCount(rawTickerObservable);
     }
 
     @Test
+    @Ignore
     public void shouldReceiveTickers() {
         Observable<Ticker> tickerObservable = streamingMarketDataService.getTicker(xbtUsd);
         awaitDataCount(tickerObservable);
@@ -85,6 +89,7 @@ public class BitmexTest {
     }
 
     @Test
+    @Ignore
     public void shouldHaveNoBookErrors() {
         streamingMarketDataService.getOrderBook(xbtUsd)
                 .test()


### PR DESCRIPTION
Sometimes tests that require an active connection to exchange cause the build to fail because of a problem on the exchange side. This PR changes all the online tests to @Ignore to avoid any possible build errors due to remote services being unavailable. Fixes #357 

To find these I literally unplugged my internet connection and ran all the tests, only @Ignore -ing the ones which failed.