### PR TITLE
Issue #561: [HitBTC] OrderBook is missing support of timestamp

### DIFF
--- a/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcOrderBookWithTimestamp.java
+++ b/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcOrderBookWithTimestamp.java
@@ -1,0 +1,40 @@
+package info.bitrich.xchangestream.hitbtc.dto;
+
+import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrderBook;
+import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrderLimit;
+
+import java.util.Date;
+
+public class HitbtcOrderBookWithTimestamp extends HitbtcOrderBook {
+
+    private final Date timestamp;
+
+    HitbtcOrderBookWithTimestamp(Date timestamp, HitbtcOrderLimit[] asks, HitbtcOrderLimit[] bids) {
+        super(asks, bids);
+        this.timestamp = timestamp;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder asks = new StringBuilder();
+        StringBuilder bids = new StringBuilder();
+
+        for (HitbtcOrderLimit ask : getAsks()) {
+            asks.append(ask).append(';');
+        }
+
+        for (HitbtcOrderLimit bid : getBids()) {
+            bids.append(bid).append(';');
+        }
+
+        return "HitbtcOrderBookWithTimestamp{" +
+                "asks=" + asks +
+                ", bids=" + bids +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
+++ b/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
@@ -3,9 +3,7 @@ package info.bitrich.xchangestream.hitbtc.dto;
 import static java.util.Collections.reverseOrder;
 
 import java.math.BigDecimal;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;
@@ -14,7 +12,6 @@ import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrderLimit;
 
 /** Created by Pavel Chertalev on 15.03.2018. */
 public class HitbtcWebSocketOrderBook {
-  private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(ZoneId.of("UTC"));
   private Map<BigDecimal, HitbtcOrderLimit> asks;
   private Map<BigDecimal, HitbtcOrderLimit> bids;
   private long sequence = 0;
@@ -41,8 +38,7 @@ public class HitbtcWebSocketOrderBook {
     }
 
     sequence = orderBookTransaction.getParams().getSequence();
-    timestamp = ZonedDateTime.parse(orderBookTransaction.getParams().getTimestamp(), DATE_FORMAT)
-            .toInstant().toEpochMilli();
+    timestamp = ZonedDateTime.parse(orderBookTransaction.getParams().getTimestamp()).toInstant().toEpochMilli();
   }
 
   public HitbtcOrderBook toHitbtcOrderBook() {
@@ -59,8 +55,7 @@ public class HitbtcWebSocketOrderBook {
     updateOrderBookItems(orderBookTransaction.getParams().getAsk(), asks);
     updateOrderBookItems(orderBookTransaction.getParams().getBid(), bids);
     sequence = orderBookTransaction.getParams().getSequence();
-    timestamp = ZonedDateTime.parse(orderBookTransaction.getParams().getTimestamp(), DATE_FORMAT)
-            .toInstant().toEpochMilli();
+    timestamp = ZonedDateTime.parse(orderBookTransaction.getParams().getTimestamp()).toInstant().toEpochMilli();
   }
 
   private void updateOrderBookItems(

--- a/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
+++ b/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBook.java
@@ -3,6 +3,11 @@ package info.bitrich.xchangestream.hitbtc.dto;
 import static java.util.Collections.reverseOrder;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrderBook;
@@ -10,9 +15,13 @@ import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrderLimit;
 
 /** Created by Pavel Chertalev on 15.03.2018. */
 public class HitbtcWebSocketOrderBook {
+  // To parse dates in format of '2018-11-19T05:00:28.700Z'
+  private static DateTimeFormatter DATE_FORMAT =
+          new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").toFormatter();
   private Map<BigDecimal, HitbtcOrderLimit> asks;
   private Map<BigDecimal, HitbtcOrderLimit> bids;
   private long sequence = 0;
+  private long timestamp = 0;
 
   public HitbtcWebSocketOrderBook(HitbtcWebSocketOrderBookTransaction orderbookTransaction) {
     createFromLevels(orderbookTransaction);
@@ -35,16 +44,22 @@ public class HitbtcWebSocketOrderBook {
     }
 
     sequence = orderbookTransaction.getParams().getSequence();
+    timestamp = parseISOTimestampInUTC(orderbookTransaction.getParams().getTimestamp());
+  }
+
+  private long parseISOTimestampInUTC(String timestamp) {
+    if (timestamp != null) {
+        LocalDateTime time = LocalDateTime.parse(timestamp, DATE_FORMAT);
+        return time.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+    return 0L;
   }
 
   public HitbtcOrderBook toHitbtcOrderBook() {
-    HitbtcOrderLimit[] askLimits =
-        asks.entrySet().stream().map(Map.Entry::getValue).toArray(HitbtcOrderLimit[]::new);
+    HitbtcOrderLimit[] asks = this.asks.values().toArray(new HitbtcOrderLimit[0]);
+    HitbtcOrderLimit[] bids = this.bids.values().toArray(new HitbtcOrderLimit[0]);
 
-    HitbtcOrderLimit[] bidLimits =
-        bids.entrySet().stream().map(Map.Entry::getValue).toArray(HitbtcOrderLimit[]::new);
-
-    return new HitbtcOrderBook(askLimits, bidLimits);
+    return new HitbtcOrderBookWithTimestamp(new Date(timestamp), asks, bids);
   }
 
   public void updateOrderBook(HitbtcWebSocketOrderBookTransaction orderBookTransaction) {
@@ -54,6 +69,7 @@ public class HitbtcWebSocketOrderBook {
     updateOrderBookItems(orderBookTransaction.getParams().getAsk(), asks);
     updateOrderBookItems(orderBookTransaction.getParams().getBid(), bids);
     sequence = orderBookTransaction.getParams().getSequence();
+    timestamp = parseISOTimestampInUTC(orderBookTransaction.getParams().getTimestamp());
   }
 
   private void updateOrderBookItems(

--- a/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBookParams.java
+++ b/xchange-stream-hitbtc/src/main/java/info/bitrich/xchangestream/hitbtc/dto/HitbtcWebSocketOrderBookParams.java
@@ -1,6 +1,7 @@
 package info.bitrich.xchangestream.hitbtc.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import info.bitrich.xchangestream.hitbtc.dto.HitbtcWebSocketBaseParams;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrderLimit;
 
 /** Created by Pavel Chertalev on 15.03.2018. */
@@ -9,16 +10,19 @@ public class HitbtcWebSocketOrderBookParams extends HitbtcWebSocketBaseParams {
   private final HitbtcOrderLimit[] ask;
   private final HitbtcOrderLimit[] bid;
   private final long sequence;
+  private final String timestamp;
 
   public HitbtcWebSocketOrderBookParams(
-      @JsonProperty("property") String symbol,
+      @JsonProperty("symbol") String symbol,
       @JsonProperty("sequence") long sequence,
       @JsonProperty("ask") HitbtcOrderLimit[] ask,
-      @JsonProperty("bid") HitbtcOrderLimit[] bid) {
+      @JsonProperty("bid") HitbtcOrderLimit[] bid,
+      @JsonProperty("timestamp") String timestamp) {
     super(symbol);
     this.ask = ask;
     this.bid = bid;
     this.sequence = sequence;
+    this.timestamp = timestamp;
   }
 
   public HitbtcOrderLimit[] getAsk() {
@@ -31,5 +35,9 @@ public class HitbtcWebSocketOrderBookParams extends HitbtcWebSocketBaseParams {
 
   public long getSequence() {
     return sequence;
+  }
+
+  public String getTimestamp() {
+    return timestamp;
   }
 }

--- a/xchange-stream-hitbtc/src/test/resources/example/notificationSnapshotOrderBook.json
+++ b/xchange-stream-hitbtc/src/test/resources/example/notificationSnapshotOrderBook.json
@@ -31,6 +31,7 @@
       }
     ],
     "symbol": "ETHBTC",
-    "sequence": 8073827
+    "sequence": 8073827,
+    "timestamp": "2020-05-03T18:26:28.714Z"
   }
 }


### PR DESCRIPTION
Timestamp attribute is added to HitbtcOrderBookWithTimestamp (extension of HitbtcOrderBook)